### PR TITLE
folder select and random orders customize.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,17 @@
                 "background.customImages": {
                     "type": "array",
                     "default": [],
-                    "description": "Your custom Images(Max length is 3). 自己定制背景图，最多3个"
+                    "description": "Your custom Images. 自己定制背景图"
+                },
+                "background.useRandom": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use random order."
+                },
+                "background.customImageFolders": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Your custom image folders. (selected randomly) "
                 }
             }
         }

--- a/src/background.ts
+++ b/src/background.ts
@@ -187,7 +187,8 @@ class Background {
         let arr = []; // 默认图片
 
         if (!config.useDefault) { // 自定义图片
-            arr = config.customImages;
+            //arr = config.customImages;
+            arr = this.getImageList();
         }
 
         // 自定义的样式内容
@@ -235,7 +236,38 @@ class Background {
         content = content.replace(/\s*$/, '');
         return content;
     }
-
+    /**
+     * get and random order images
+     *
+     * @private
+     * @returns {array}
+     * @memberof Background
+     */
+    private getImageList(): string[] {
+        let config = this.config;
+        let folders:string[] = config.customImageFolders;
+        let arr:string[] = [];
+        if(folders.length > 0){
+            let fdpath:string = folders[Math.floor( Math.random() * folders.length )];
+            let files:string[] = fs.readdirSync(path.resolve(fdpath));
+            files.filter((s) => {
+                return s.endsWith('.png') || s.endsWith('.jpg') || s.endsWith('.gif');
+            }).forEach((file) => {
+                arr.push( path.join(fdpath,file).toString().replace(/\\/g,'/') ) ;
+            });
+        }else{
+            arr = config.customImages;
+        }
+        if(config.useRandom){ 
+            for(let i:number = arr.length - 1; i > 0; i--){
+                let r:number = Math.floor(Math.random() * (i + 1));
+                let tmp = arr[i];
+                arr[i] = arr[r];
+                arr[r] = tmp;
+            }
+        }
+        return arr;
+    }
     //#endregion
 
     //#region public methods


### PR DESCRIPTION
Enable image selection from the folder selected randomly from 【background.customImageFolders】.
And if【background.useRandom】is true sort randomly.
Only default images can not be sorted.
If you do not have these settings, I will do the same as before.

folders path pattern
```
    "background.customImageFolders": [
        "c:\\Users\\hot3\\Pictures\\vscode\\sao01\\",
        "c:\\Users\\hot3\\Pictures\\vscode\\sao02",
        "c:/Users/hot3/Pictures/vscode/nisekoi01",
        "c:/Users/hot3/Pictures/vscode/nisekoi02/",
        "/Users/hot3/Pictures/vscode/konosuba01",
        "/Users/hot3/Pictures/vscode/konosuba02/",
    ],
```

I understand. What you want to be able to display random images on tabs.
So I tried to fix to minimize main logic correction and enjoy.

I use this function to divide by animation type and image size.
Because it is not well balanced.

Also,I did not put restart 's logic this time, but I am enjoying it so that I can call it from the command.
It is because you do not need administrator privileges and it is easy to use.
Please consider it if you like.
