### PR TITLE
添加卸载钩子

### DIFF
--- a/assets/uninstall.js
+++ b/assets/uninstall.js
@@ -1,0 +1,52 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
+
+// 文件路径
+const base = process.cwd();
+const filePath = path.join(base, 'resources', 'app', 'out', 'vs', 'workbench', 'workbench.main.css');
+
+
+//执行清理操作
+try {
+	var content = getContent();
+	content = clearCssContent(content);
+	saveContent(content);
+	return true;
+}catch (ex) {
+	return false;
+}
+
+
+/**
+ * 获取文件内容
+ * @var mixed
+ */
+function getContent() {
+	return fs.readFileSync(filePath, 'utf-8');
+}
+/**
+ * 设置文件内容
+ *
+ * @private
+ * @param {string} content
+ */
+function saveContent(content) {
+	fs.writeFileSync(filePath, content, 'utf-8');
+}
+/**
+ * 清理已经添加的代码
+ *
+ * @private
+ * @param {string} content
+ * @returns {string}
+ */
+function clearCssContent(content) {
+	content = content.replace(/\/\*css-background-start\*\/[\s\S]*?\/\*css-background-end\*\//g, '');
+	content = content.replace(/\s*$/, '');
+	return content;
+}
+
+
+//node D:\code\TypeScript\vscode-background-cover\resources\uninstall.js

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
+        "vscode:uninstall": "node ./assets/uninstall.js",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
给扩展加了一个卸载钩子，即使用户卸载扩展时忘记禁用扩展配置，只需要卸载后关闭vscode，再手动打开就会自动执行钩子清理css,重启vscode即可。