### PR TITLE
fix: fix-repository-link

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/shalldie/vscode-background.git"
+        "url": "https://github.com/shalldie/vscode-background.git"
     },
     "engines": {
         "vscode": "^1.17.0"


### PR DESCRIPTION
vs-code show message "Unable to open 'vscode-background.git': resource is not available" after click "Repository" in extension page 

![Screen Shot 2562-10-10 at 13 01 23](https://user-images.githubusercontent.com/1756190/66542941-244d2700-eb5e-11e9-8a27-785d34840340.png)
