### PR TITLE
add feature: apply css with sudo - 自动提权写入css文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,10 +86,14 @@
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
+    "dependencies": {
+        "sudo-prompt": "9.1.1"
+    },
     "devDependencies": {
         "typescript": "^2.5.3",
         "vscode": "^1.1.5",
         "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+        "@types/mocha": "^2.2.42",
+        "sudo-prompt": "9.1.1"
     }
 }

--- a/src/vscodePath.ts
+++ b/src/vscodePath.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { execPath } from 'process'
 
 // 基础目录
 const base = path.dirname(require.main.filename);
@@ -10,6 +11,34 @@ const cssPath = path.join(base, 'vs', 'workbench', cssName);
 
 // electron 入口文件所在文件夹
 const indexDir = path.join(base, 'vs', 'workbench', 'electron-browser', 'bootstrap');
+
+function getCLIPath(): string {
+    // TODO: 这两个变量不知道取的对不对
+    let isBuilt = !process.env['VSCODE_DEV'];
+    let appRoot = base;
+    // TODO: 实在不知道怎么取了。。直接默认值
+    let applicationName = 'code';
+    // 下边代码来自vscode源码/src/vs/platform/environment/node/environmentService.ts line:48
+    // Windows
+    if (process.platform == 'win32') {
+        if (isBuilt) {
+            return path.join(path.dirname(execPath), 'bin', `${applicationName}.cmd`);
+        }
+        return path.join(appRoot, 'scripts', 'code-cli.bat');
+    }
+    // Linux
+    if (process.platform == 'linux' || process.platform == 'android') {
+        if (isBuilt) {
+            return path.join(path.dirname(execPath), 'bin', `${applicationName}`);
+        }
+        return path.join(appRoot, 'scripts', 'code-cli.sh');
+    }
+    // macOS
+    if (isBuilt) {
+        return path.join(appRoot, 'bin', 'code');
+    }
+    return path.join(appRoot, 'scripts', 'code-cli.sh');
+}
 
 export default {
     /**
@@ -23,5 +52,6 @@ export default {
     /**
      * electron 入口文件所在文件夹
      */
-    indexDir
+    indexDir,
+    getCLIPath
 };


### PR DESCRIPTION
在修改背景设置css文件时，如果当前用户没有权限修改软件css文件，插件会自动弹出提示认证到管理员，并自动以管理员身份(sudo)写入新的css文件。
(在linux中测试通过，win/mac理论支持但未测试)
QGroup: 367341477