### PR TITLE
添加图片循环使用

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                     "type": "array",
                     "default": [],
                     "description": "Your custom Images(Max length is 3). 自己定制背景图，最多3个"
+                },
+                "background.loop": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Loop use Images. 循环使用图片"
                 }
             }
         }

--- a/src/background.ts
+++ b/src/background.ts
@@ -205,7 +205,7 @@ class Background {
         }
 
         // 自定义的样式内容
-        const content = getCss(arr, config.style, config.styles, config.useFront).replace(/\s*$/, ''); // 去除末尾空白
+        const content = getCss(arr, config.style, config.styles, config.useFront, config.loop).replace(/\s*$/, ''); // 去除末尾空白
 
         // 添加到原有样式(尝试删除旧样式)中
         let cssContent = this.getCssContent();

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -55,7 +55,7 @@ export default function (
     style: any = {},
     styles: Array<any> = [],
     useFront = true,
-    loop: boolean = false
+    loop = false
 ): string {
     const defStyle = getStyleByOptions(style, useFront); // 默认样式
     let images = (arr && arr.length) ? arr : defBase64;
@@ -67,21 +67,21 @@ export default function (
     if (!loop) {
         // 非循环使用生成nth-child(index + 1)
         images.forEach((item, index) => {
-            const n = `${index + 1}`
-            const otherStyle = defStyle + getStyleByOptions(styles[index], useFront)
-            content += genStyleItem(n, item, useFront, otherStyle) + '\n'
-        })
+            const n = `${index + 1}`;
+            const otherStyle = defStyle + getStyleByOptions(styles[index], useFront);
+            content += genStyleItem(n, item, useFront, otherStyle) + '\n';
+        });
     } else {
         // 循环使用逆序循环生成nth-child(length * n - index)
-        images = images.reverse()
-        const styleList = styles.reverse()
-        const length = images.length
+        images = images.reverse();
+        const styleList = styles.reverse();
+        const length = images.length;
 
         images.forEach((item, index) => {
-            const n = `${length}n - ${index}`
-            const otherStyle = defStyle + getStyleByOptions(styleList[index], useFront)
-            content += genStyleItem(n, item, useFront, otherStyle) + '\n'
-        })
+            const n = `${length}n - ${index}`;
+            const otherStyle = defStyle + getStyleByOptions(styleList[index], useFront);
+            content += genStyleItem(n, item, useFront, otherStyle) + '\n';
+        });
     }
 
     // 追加额外样式

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -25,6 +25,21 @@ function getStyleByOptions(options: object, useFront: boolean): string {
 }
 
 /**
+ * 生成样式项
+ * @param n             nth-child的参数
+ * @param url           图片url
+ * @param useFront      是否使用前景图
+ * @param otherStyle    追加的额外样式
+ */
+function genStyleItem(n: string, url: string, useFront: boolean, otherStyle: string): string {
+    const frontContent = useFront ? '::after' : '::before';
+    let selector = `[id="workbench.parts.editor"] .split-view-view:nth-child(${n}) .editor-container `;
+    selector += `.editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}`;
+
+    return `${selector} { background-image: url('${url}'); ${otherStyle} }`;
+}
+
+/**
  * 生成css样式
  *
  * @export
@@ -32,42 +47,48 @@ function getStyleByOptions(options: object, useFront: boolean): string {
  * @param {any} [style={}] 自定义样式
  * @param {Array<any>} [styles=[]] 每个背景图的自定义样式
  * @param {boolean} [useFront=true] 是否用前景图
+ * @param {boolean} [loop=false] 是否循环使用图片
  * @returns
  */
-export default function (arr: Array<string>, style: any = {}, styles: Array<any> = [], useFront = true): string {
-    const [img0, img1, img2] = (arr && arr.length)
-        ? [
-            arr[0] || 'none',
-            arr[1] || 'none',
-            arr[2] || 'none'
-        ]
-        : defBase64;
-
+export default function (
+    arr: Array<string>,
+    style: any = {},
+    styles: Array<any> = [],
+    useFront = true,
+    loop: boolean = false
+): string {
     const defStyle = getStyleByOptions(style, useFront); // 默认样式
-    const [styel0, style1, style2] = [                   // 3个子项样式
-        defStyle + getStyleByOptions(styles[0], useFront),
-        defStyle + getStyleByOptions(styles[1], useFront),
-        defStyle + getStyleByOptions(styles[2], useFront)
-    ];
+    let images = (arr && arr.length) ? arr : defBase64;
+    let content = '\n/*css-background-start*/\n';
 
-    // 在前景图时使用 ::after
-    const frontContent = useFront ? '::after' : '::before';
+    // 追加版本号
+    content += `/*${BACKGROUND_VER}.${version}*/\n`;
 
-    const content = `
+    if (!loop) {
+        // 非循环使用生成nth-child(index + 1)
+        images.forEach((item, index) => {
+            const n = `${index + 1}`
+            const otherStyle = defStyle + getStyleByOptions(styles[index], useFront)
+            content += genStyleItem(n, item, useFront, otherStyle) + '\n'
+        })
+    } else {
+        // 循环使用逆序循环生成nth-child(length * n - index)
+        images = images.reverse()
+        const styleList = styles.reverse()
+        const length = images.length
 
-/*css-background-start*/
-/*${BACKGROUND_VER}.${version}*/
+        images.forEach((item, index) => {
+            const n = `${length}n - ${index}`
+            const otherStyle = defStyle + getStyleByOptions(styleList[index], useFront)
+            content += genStyleItem(n, item, useFront, otherStyle) + '\n'
+        })
+    }
 
-[id="workbench.parts.editor"] .split-view-view:nth-child(1) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}{background-image: url('${img0}');${styel0}}
+    // 追加额外样式
+    content += '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element>.monaco-editor-background{background: none;}\n';
 
-[id="workbench.parts.editor"] .split-view-view:nth-child(2) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}{background-image: url('${img1}');${style1}}
-
-[id="workbench.parts.editor"] .split-view-view:nth-child(3) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}{background-image: url('${img2}');${style2}}
-
-[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element>.monaco-editor-background{background: none;}
-
-/*css-background-end*/
-`;
+    // 追加结束标志
+    content += '/*css-background-end*/\n';
 
     return content;
 }


### PR DESCRIPTION
添加了一个设置项: background.loop 用于配置循环使用图片. 同时解决了自定义图片只能配置三张的问题

开启前:
![image](https://user-images.githubusercontent.com/20502666/81495276-ce05b980-92e1-11ea-867a-5afb0f83a50b.png)

开启后:
![image](https://user-images.githubusercontent.com/20502666/81495287-d78f2180-92e1-11ea-9751-383a43f1ee35.png)
