### PR TITLE
一堆功能提交

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run compile
+    - run: npm run package
+    - uses: actions/upload-artifact@v3
+      with:
+        name: build-artifact
+        path: '*.vsix'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/**/*.js" ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: compile"
         },
         {
             "name": "Launch Tests",

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ vsc-extension-quickstart.md
 package-lock.json
 .huskyrc
 .prettierignore
+.github

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ You should use protocol **https** instead of **http** for the image, **http** is
 
 ## Uninstall 卸载
 
+    Type <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> key to open command panel. And then use the `Background - Uninstall (remove extension)` command to complete the uninstall.
+
+    按 <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> 打开命令面板后，输入`Background - Uninstall (remove extension)`以完成卸载。
+
     Set the config  {"background.enabled": false}  in settings.json, then uninstall the plugin.
 
-    需要在 settings.json 中设置 {"background.enabled": false} ，然后再删除插件。如果直接删除插件会有遗留，就需要重装vscode，或者把插件装回来再执行该步骤。
+    需要在 settings.json 中设置 {"background.enabled": false} ，然后再删除插件。
 
 ### Q&A 常见问题:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,10 +284,43 @@
       "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
       "dev": true
     },
+    "azure-devops-node-api": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmmirror.com/azure-devops-node-api/-/azure-devops-node-api-11.1.1.tgz",
+      "integrity": "sha512-XDG91XzLZ15reP12s3jFkKS8oiagSICjnLwxEYieme4+4h3ZveFOFRA4iYIG40RyHXsiI0mefFYYMFIJbMpWcg==",
+      "dev": true,
+      "requires": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/balanced-match/download/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "brace-expansion": {
@@ -307,6 +340,32 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -366,6 +425,50 @@
         }
       }
     },
+    "cheerio": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmmirror.com/cheerio/-/cheerio-1.0.0-rc.11.tgz",
+      "integrity": "sha512-bQwNaDIBKID5ts/DsdhxrjqFXYfLw4ste+wMKqWA8DyKcS4qwsPP4Bk8ZNaTJjvpiX/qW3BT4sU7d6Bh5i+dag==",
+      "dev": true,
+      "requires": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmmirror.com/color-convert/download/color-convert-1.9.3.tgz",
@@ -379,6 +482,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmmirror.com/color-name/download/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
     "concat-map": {
@@ -398,6 +507,25 @@
         "which": "^2.0.1"
       }
     },
+    "css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmmirror.com/debug/download/debug-4.3.3.tgz",
@@ -407,10 +535,31 @@
         "ms": "2.1.2"
       }
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmmirror.com/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmmirror.com/deep-is/download/deep-is-0.1.4.tgz",
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "dev": true
     },
     "dir-glob": {
@@ -431,11 +580,57 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmmirror.com/emoji-regex/download/emoji-regex-8.0.0.tgz?cache=0&sync_timestamp=1632752198735&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Femoji-regex%2Fdownload%2Femoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -445,6 +640,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -636,6 +837,12 @@
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz",
@@ -682,6 +889,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/file-entry-cache/download/file-entry-cache-6.0.1.tgz",
@@ -716,16 +932,45 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/fs.realpath/download/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmmirror.com/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true
     },
     "glob": {
@@ -774,16 +1019,58 @@
         "slash": "^3.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/has-flag/download/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
     "husky": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/husky/download/husky-6.0.0.tgz",
       "integrity": "sha1-gQ8RhprfUWBMMupXftvDd9f5MZ4=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {
@@ -822,6 +1109,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmmirror.com/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "is-extglob": {
@@ -885,6 +1178,22 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmmirror.com/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmmirror.com/levn/download/levn-0.4.1.tgz",
@@ -893,6 +1202,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "lodash.merge": {
@@ -916,6 +1234,39 @@
         "yallist": "^4.0.0"
       }
     },
+    "markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmmirror.com/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmmirror.com/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "dev": true
+        }
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmmirror.com/merge2/download/merge2-1.4.1.tgz",
@@ -932,6 +1283,18 @@
         "picomatch": "^2.2.3"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmmirror.com/minimatch/download/minimatch-3.0.4.tgz",
@@ -941,16 +1304,70 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmmirror.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/ms/download/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmmirror.com/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/natural-compare/download/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node-abi": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmmirror.com/node-abi/-/node-abi-3.22.0.tgz",
+      "integrity": "sha512-u4uAs/4Zzmp/jjsD9cyFYDXeISfUWaAVWshPmDZOFOv4Xl4SbzTXm53I04C2uRueYJ+0t5PEtLH/owbn2Npf/w==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "once": {
@@ -985,6 +1402,42 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmmirror.com/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "parse5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "dev": true,
+      "requires": {
+        "entities": "^4.3.0"
+      }
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dev": true,
+      "requires": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
@@ -1003,11 +1456,37 @@
       "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmmirror.com/picomatch/download/picomatch-2.3.0.tgz",
       "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
       "dev": true
+    },
+    "prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -1036,17 +1515,76 @@
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/punycode/download/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
+    "qs": {
+      "version": "6.10.5",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.10.5.tgz",
+      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmmirror.com/queue-microtask/download/queue-microtask-1.2.3.tgz",
       "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+          "dev": true
+        }
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "regexpp": {
       "version": "3.2.0",
@@ -1090,6 +1628,18 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmmirror.com/semver/download/semver-7.3.5.tgz",
@@ -1113,6 +1663,34 @@
       "resolved": "https://registry.npmmirror.com/shebang-regex/download/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "slash": {
       "version": "3.0.0",
@@ -1174,6 +1752,15 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-6.0.1.tgz",
@@ -1188,6 +1775,11 @@
       "resolved": "https://registry.npmmirror.com/strip-json-comments/download/strip-json-comments-3.1.1.tgz",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true
+    },
+    "sudo-prompt": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmmirror.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
+      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -1231,11 +1823,45 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmmirror.com/text-table/download/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmmirror.com/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -1261,6 +1887,21 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmmirror.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/type-check/download/type-check-0.4.0.tgz",
@@ -1276,10 +1917,33 @@
       "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
       "dev": true
     },
+    "typed-rest-client": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmmirror.com/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
     "typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmmirror.com/typescript/download/typescript-4.5.4.tgz",
       "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmmirror.com/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
       "dev": true
     },
     "uri-js": {
@@ -1291,11 +1955,76 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmmirror.com/v8-compile-cache/download/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
       "dev": true
+    },
+    "vsce": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmmirror.com/vsce/-/vsce-2.9.1.tgz",
+      "integrity": "sha512-l/X4hkoYgOoZhRYQpJXqexBJU2z4mzNywx+artzWnOV3v45YMM6IoDDtIcB9SWluobem476KmMPLkCdAdnvoOg==",
+      "dev": true,
+      "requires": {
+        "azure-devops-node-api": "^11.0.1",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "commander": "^6.1.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "keytar": "^7.7.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^5.1.0",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.4.23",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmmirror.com/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmmirror.com/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -1318,11 +2047,46 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmmirror.com/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmmirror.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/yallist/download/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmmirror.com/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         },
         "background.minimapOpacity": {
           "type": "number",
-          "default": null,
+          "default": 1,
           "description": "Make Minimap transparent. 使Minimap透明"
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,22 @@
           "type": "number",
           "default": 1,
           "description": "Make Minimap transparent. 使Minimap透明"
+        },
+        "background.customBackgroundSelectors": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "自定义将要应用背景的元素的选择器"
+        },
+        "background.customRemoveBackgroundSelectors": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "自定义将要删除背景的元素的选择器"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lint": "eslint . --ext .ts src",
-    "fix": "eslint . --fix --ext .ts src"
+    "fix": "eslint . --fix --ext .ts src",
+    "package": "npx vsce package"
   },
   "devDependencies": {
     "@types/node": "^15.12.5",
@@ -149,7 +150,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": "^6.0.0",
     "prettier": "^2.3.2",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.4",
+    "vsce": "^2.9.1"
   },
   "dependencies": {
     "sudo-prompt": "^9.2.1"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       {
         "command": "extension.background.info",
         "title": "Background - Info"
+      },
+      {
+        "command": "extension.background.uninstall",
+        "title": "Background - Uninstall (remove extension)"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,10 @@
         "background.customImages": {
           "type": "array",
           "default": [],
-          "description": "Your custom images. 自己定制背景图"
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Your custom images. 自己定制背景图  \nYou must add the `file://` prefix when you use local files!  \n当您使用本地文件时，您**必须**添加`file://`前缀！"
         },
         "background.loop": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "husky": "^6.0.0",
     "prettier": "^2.3.2",
     "typescript": "^4.3.4"
+  },
+  "dependencies": {
+    "sudo-prompt": "^9.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,19 +98,35 @@
         },
         "background.customBackgroundSelectors": {
           "type": "array",
-          "default": [],
+          "default": [
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}",
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.gettingStartedContainer::before",
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.extension-editor::before",
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-diff-editor .editor .monaco-editor::before",
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.settings-editor::before",
+            "[id=\"workbench.parts.editor\"] .split-view-view:nth-child(${nthChildIndex}) .empty::before"
+          ],
           "items": {
             "type": "string"
           },
-          "description": "自定义将要应用背景的元素的选择器"
+          "description": "Customize the selector of the element to which the background will be applied. 自定义将要应用背景的元素的选择器"
         },
         "background.customRemoveBackgroundSelectors": {
           "type": "array",
-          "default": [],
+          "default": [
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element>.monaco-editor-background",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor .monaco-editor-background",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.settings-editor .settings-body .split-view-container .settings-tree-container>.monaco-list>.monaco-scrollable-element>.monaco-list-rows",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.settings-editor .settings-body .split-view-container .settings-tree-container>.monaco-list>.monaco-scrollable-element>.monaco-list-rows>.monaco-list-row",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.settings-editor .settings-body .split-view-container .settings-tree-container>.monaco-list>.monaco-scrollable-element>.monaco-list-rows>.monaco-list-row.focused",
+            "[id=\"workbench.parts.editor\"] .split-view-view .editor-container .editor-instance>.settings-editor .settings-body .split-view-container .settings-tree-container>.monaco-list>.monaco-scrollable-element>.monaco-list-rows>.monaco-list-row.selected"
+          ],
           "items": {
             "type": "string"
           },
-          "description": "自定义将要删除背景的元素的选择器"
+          "description": "Customize the selector of the element whose background will be removed. 自定义将要删除背景的元素的选择器"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "type": "boolean",
           "default": false,
           "description": "Loop your images. 循环使用图片"
+        },
+        "background.minimapOpacity": {
+          "type": "number",
+          "default": null,
+          "description": "Make Minimap transparent. 使Minimap透明"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "activationEvents": [
     "onStartupFinished"
   ],
+  "extensionKind": [
+    "ui"
+  ],
   "main": "./out/extension",
   "contributes": {
     "commands": [

--- a/src/background.ts
+++ b/src/background.ts
@@ -202,7 +202,14 @@ class Background {
         }
 
         // 自定义的样式内容
-        const content = getCss(arr, config.style, config.styles, config.useFront, config.loop).replace(/\s*$/, ''); // 去除末尾空白
+        const content = getCss(
+            arr,
+            config.style,
+            config.styles,
+            config.useFront,
+            config.loop,
+            config.minimapOpacity
+        ).trimEnd(); // 去除末尾空白
 
         // 添加到原有样式(尝试删除旧样式)中
         let cssContent = this.getCssContent();

--- a/src/background.ts
+++ b/src/background.ts
@@ -139,6 +139,12 @@ class Background {
         }
     }
 
+    /**
+     * 提权运行命令
+     * @param cmd 命令
+     * @param options 选项
+     * @returns 命令输出
+     */
     private async sudoCommand(
         cmd: string,
         options?: { name?: string; icns?: string; env?: { [key: string]: string } }
@@ -158,6 +164,11 @@ class Background {
         });
     }
 
+    /**
+     * 保存CSS到临时文件
+     * @param content CSS文件内容
+     * @returns 临时文件路径
+     */
     private async saveCssContentToTemp(content: string): Promise<string> {
         const tempPath = path.resolve(tmpdir(), `vscode-background-${randomUUID()}.css`);
         await fsp.writeFile(tempPath, content, ENCODE);

--- a/src/background.ts
+++ b/src/background.ts
@@ -208,7 +208,9 @@ class Background {
             config.styles,
             config.useFront,
             config.loop,
-            config.minimapOpacity
+            config.minimapOpacity,
+            config.customBackgroundSelectors,
+            config.customRemoveBackgroundSelectors
         ).trimEnd(); // 去除末尾空白
 
         // 添加到原有样式(尝试删除旧样式)中

--- a/src/background.ts
+++ b/src/background.ts
@@ -170,14 +170,14 @@ class Background {
      * @private
      * @memberof Background
      */
-    private initialize(): void {
+    private async initialize(): Promise<void> {
         const firstload = this.checkFirstload(); // 是否初次加载插件
 
         const fileType = this.fileType; // css 文件目前状态
 
         // 如果是第一次加载插件，或者旧版本
         if (firstload || fileType == ECSSEditType.isOld || fileType == ECSSEditType.noModified) {
-            this.install(true);
+            await this.install(true);
         }
     }
 
@@ -213,7 +213,7 @@ class Background {
      * @returns {void}
      * @memberof Background
      */
-    private install(refresh?: boolean): void {
+    private async install(refresh?: boolean): Promise<void> {
         const lastConfig = this.config; // 之前的配置
         const config = vscode.workspace.getConfiguration('background'); // 当前用户配置
 
@@ -236,8 +236,8 @@ class Background {
 
         // 4.如果关闭插件
         if (!config.enabled) {
-            this.uninstall();
-            vsHelp.showInfoRestart('Background has been uninstalled! Please restart.');
+            await this.uninstall();
+            await vsHelp.showInfoRestart('Background has been uninstalled! Please restart.');
             return;
         }
 
@@ -266,8 +266,8 @@ class Background {
         cssContent = this.clearCssContent(cssContent);
         cssContent += content;
 
-        this.saveCssContent(cssContent);
-        vsHelp.showInfoRestart('Background has been changed! Please restart.');
+        await this.saveCssContent(cssContent);
+        await vsHelp.showInfoRestart('Background has been changed! Please restart.');
     }
 
     /**
@@ -294,11 +294,11 @@ class Background {
      * @returns {boolean}
      * @memberof Background
      */
-    public uninstall(): boolean {
+    public async uninstall(): Promise<boolean> {
         try {
             let content = this.getCssContent();
             content = this.clearCssContent(content);
-            this.saveCssContent(content);
+            await this.saveCssContent(content);
             return true;
         } catch (ex) {
             console.log(ex);
@@ -312,9 +312,9 @@ class Background {
      * @returns {vscode.Disposable}
      * @memberof Background
      */
-    public watch(): vscode.Disposable {
-        this.initialize();
-        return vscode.workspace.onDidChangeConfiguration(() => this.install());
+    public async watch(): Promise<vscode.Disposable> {
+        await this.initialize();
+        return vscode.workspace.onDidChangeConfiguration(async () => await this.install());
     }
 
     //#endregion

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import path from 'path';
 import sudo from 'sudo-prompt';
 
@@ -122,6 +123,7 @@ class Background {
             return false;
         }
         try {
+            await fs.access(vscodePath.cssPath, fsConstants.W_OK);
             await fs.writeFile(vscodePath.cssPath, content, ENCODE);
             return true;
         } catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { vsHelp } from './vsHelp';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
     // Use the console to output diagnostic information (console.log) and errors (console.error)
     // This line of code will only be executed once when your extension is activated
     // console.log('Congratulations, your extension "background" is now active!');
@@ -21,18 +21,18 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(disposable);
 
-    context.subscriptions.push(background.watch());
+    context.subscriptions.push(await background.watch());
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('extension.background.uninstall', () => {
+        vscode.commands.registerCommand('extension.background.uninstall', async () => {
             if (!background.hasInstalled) {
                 return;
             }
 
-            background.uninstall();
-            vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
             const msg = 'background extension has been uninstalled. See You Next Time! ';
-            vsHelp.showInfoRestart(msg, msg);
+            await background.uninstall();
+            await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
+            await vsHelp.showInfoRestart(msg, msg);
         })
     );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,19 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(disposable);
 
     context.subscriptions.push(background.watch());
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.background.uninstall', () => {
+            if (!background.hasInstalled) {
+                return;
+            }
+
+            background.uninstall();
+            vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
+            const msg = 'background extension has been uninstalled. See You Next Time! ';
+            vsHelp.showInfoRestart(msg, msg);
+        })
+    );
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,9 +30,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
 
             const msg = 'background extension has been uninstalled. See You Next Time! ';
-            await background.uninstall();
-            await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
-            await vsHelp.showInfoRestart(msg, msg);
+            if (await background.uninstall()) {
+                // 当且仅当成功删除样式时才会卸载扩展
+                // 否则可能导致没有成功删掉样式时扩展就被卸载掉
+                await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
+                await vsHelp.showInfoRestart(msg, msg);
+            }
         })
     );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     context.subscriptions.push(
         vscode.commands.registerCommand('extension.background.uninstall', async () => {
-            if (!background.hasInstalled) {
+            if (!(await background.hasInstalled())) {
                 return;
             }
 

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -165,6 +165,8 @@ const makeImageStyleContent = (
         // 空页面选择器
         `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .empty::before`,
         // 自定义选择器
-        ...customBackgroundSelectors
+        ...customBackgroundSelectors.map(str =>
+            str.replace('${nthChildIndex}', nthChildIndex).replace('${frontContent}', frontContent).trim()
+        )
     );
 };

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -154,16 +154,6 @@ const makeImageStyleContent = (
     return setBackground(
         img,
         styleContent,
-        // 代码编辑器选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}`,
-        // “开始”欢迎页面选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.gettingStartedContainer::before`,
-        // 扩展编辑器视图选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.extension-editor::before`,
-        // 差异编辑器视图选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-diff-editor .editor .monaco-editor::before`,
-        // 空页面选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .empty::before`,
         // 自定义选择器
         ...customBackgroundSelectors.map(str =>
             str.replace('${nthChildIndex}', nthChildIndex).replace('${frontContent}', frontContent).trim()

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -98,10 +98,12 @@ export function getCss(
             const codeEditorSelector = `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element${frontContent}`;
             // “开始”欢迎页面选择器
             const startedPageSelector = `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.gettingStartedContainer::before`;
+            // 扩展编辑器视图选择器
+            const extEditorSelector = `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.extension-editor::before`;
             // 空页面选择器
             const emptyViewSelector = `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .empty::before`;
 
-            return /* css */ `${codeEditorSelector},${startedPageSelector},${emptyViewSelector}{background-image:url('${img}');${styleContent}}`;
+            return /* css */ `${codeEditorSelector},${startedPageSelector},${extEditorSelector},${emptyViewSelector}{background-image:url('${img}');${styleContent}}`;
         })
         .join('\n');
 

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -100,13 +100,6 @@ export function getCss(
         .join('\n');
 
     const removeBackground = clearBackground(
-        // 代码编辑器
-        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-editor .overflow-guard>.monaco-scrollable-element>.monaco-editor-background',
-        // 差异编辑器
-        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor',
-        // 差异编辑器 子编辑器
-        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor',
-        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor .monaco-editor-background',
         // 自定义选择器
         ...customRemoveBackgroundSelectors
     );

--- a/src/getCss.ts
+++ b/src/getCss.ts
@@ -56,7 +56,9 @@ export function getCss(
     styles: Array<any> = [],
     useFront = true,
     loop = false,
-    minimapOpacity?: number
+    minimapOpacity?: number,
+    customBackgroundSelectors?: string[],
+    customRemoveBackgroundSelectors?: string[]
 ): string {
     // ------ 默认样式 ------
     const defStyle = getStyleByOptions(style, useFront);
@@ -83,7 +85,17 @@ export function getCss(
     // ------ 组合样式 ------
     const imageStyleContent = list
         .map((img, index, arr) =>
-            makeImageStyleContent(img, index, arr, loop, useFront, frontContent, defStyle, styles)
+            makeImageStyleContent(
+                img,
+                index,
+                arr,
+                loop,
+                useFront,
+                frontContent,
+                defStyle,
+                styles,
+                customBackgroundSelectors
+            )
         )
         .join('\n');
 
@@ -94,7 +106,9 @@ export function getCss(
         '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor',
         // 差异编辑器 子编辑器
         '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor',
-        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor .monaco-editor-background'
+        '[id="workbench.parts.editor"] .split-view-view .editor-container .editor-instance>.monaco-diff-editor .editor>.monaco-editor .monaco-editor-background',
+        // 自定义选择器
+        ...customRemoveBackgroundSelectors
     );
 
     const content = wrapCssContent(minimapStyleContent, imageStyleContent, removeBackground);
@@ -123,7 +137,8 @@ const makeImageStyleContent = (
     useFront: boolean,
     frontContent: string,
     defStyle: string,
-    styles: any[]
+    styles: any[],
+    customBackgroundSelectors?: string[]
 ) => {
     // ------ nth-child ------
     // nth-child(1)
@@ -148,6 +163,8 @@ const makeImageStyleContent = (
         // 差异编辑器视图选择器
         `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .editor-container .editor-instance>.monaco-diff-editor .editor .monaco-editor::before`,
         // 空页面选择器
-        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .empty::before`
+        `[id="workbench.parts.editor"] .split-view-view:nth-child(${nthChildIndex}) .empty::before`,
+        // 自定义选择器
+        ...customBackgroundSelectors
     );
 };

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,7 +1,10 @@
 import { background } from './background';
 import { vsHelp } from './vsHelp';
 
-if (background.hasInstalled) {
-    background.uninstall();
-    vsHelp.showInfoRestart('Background has been uninstalled! Please restart.');
-}
+background.hasInstalled().then(async hasInstalled => {
+    if (hasInstalled) {
+        if (await background.uninstall()) {
+            vsHelp.showInfoRestart('Background has been uninstalled! Please restart.');
+        }
+    }
+});

--- a/src/vsHelp.ts
+++ b/src/vsHelp.ts
@@ -15,25 +15,35 @@ export const vsHelp = {
      * 提示信息并重启
      *
      * @param {string} content 提示内容
+     * @param {string} contentWhenFixChecksumsBeInstalled 当'Fix VSCode Checksums'扩展被安装时的提示内容
      * @returns {Thenable<void>}
      */
-    async showInfoRestart(content: string): Promise<void> {
+    async showInfoRestart(
+        content: string,
+        contentWhenFixChecksumsBeInstalled = "We found the 'Fix VSCode Checksums' Extension has been installed. Do you want to use it to remove [unsupported] tag? "
+    ): Promise<void> {
+        const fix = 'use Fix VSCode Checksums';
+        const restart = 'Restart vscode';
         const fixChecksums = vscode.extensions.getExtension('lehni.vscode-fix-checksums');
+
+        const items: string[] = [];
+        let msg = content;
         if (fixChecksums) {
-            const result = await vscode.window.showInformationMessage(
-                "We found the 'Fix VSCode Checksums' Extension has been installed. " +
-                    'Do you want to use it to remove [unsupported] tag? ',
-                'Yes',
-                'No'
-            );
-            if (result === 'Yes') {
-                vscode.commands.executeCommand('fixChecksums.apply');
-                return;
-            }
+            items.push(fix);
+            msg = contentWhenFixChecksumsBeInstalled;
         }
-        return vscode.window.showInformationMessage(content, { title: 'Restart vscode' }).then(function (item) {
-            if (!item) return;
-            vscode.commands.executeCommand('workbench.action.reloadWindow');
+        items.push(restart);
+
+        vscode.window.showInformationMessage(msg, ...items).then(item => {
+            switch (item) {
+                case restart:
+                    vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    break;
+                case fix:
+                    vscode.commands.executeCommand('fixChecksums.apply');
+                    vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    break;
+            }
         });
     }
 };

--- a/src/vsHelp.ts
+++ b/src/vsHelp.ts
@@ -17,7 +17,20 @@ export const vsHelp = {
      * @param {string} content 提示内容
      * @returns {Thenable<void>}
      */
-    showInfoRestart(content: string): Thenable<void> {
+    async showInfoRestart(content: string): Promise<void> {
+        const fixChecksums = vscode.extensions.getExtension('lehni.vscode-fix-checksums');
+        if (fixChecksums) {
+            const result = await vscode.window.showInformationMessage(
+                "We found the 'Fix VSCode Checksums' Extension has been installed. " +
+                    'Do you want to use it to remove [unsupported] tag? ',
+                'Yes',
+                'No'
+            );
+            if (result === 'Yes') {
+                vscode.commands.executeCommand('fixChecksums.apply');
+                return;
+            }
+        }
         return vscode.window.showInformationMessage(content, { title: 'Restart vscode' }).then(function (item) {
             if (!item) return;
             vscode.commands.executeCommand('workbench.action.reloadWindow');

--- a/src/vscodePath.ts
+++ b/src/vscodePath.ts
@@ -16,15 +16,14 @@ const cssPath = (() => {
     const defPath = getCssPath(cssName);
     const webPath = getCssPath(webCssName);
 
-    /**
-     * 暂时没想到怎么判断在 web 中使用，比如 code-server。暂时这么处理吧
-     * 之后需要加上鉴权处理
-     */
-    if (!fs.existsSync(defPath) && fs.existsSync(webPath)) {
-        return webPath;
+    // See https://code.visualstudio.com/api/references/vscode-api#env
+    switch (vscode.env.appHost) {
+        case 'desktop':
+            return defPath;
+        case 'web':
+        default:
+            return webPath;
     }
-
-    return defPath;
 })();
 
 // electron 入口文件所在文件夹


### PR DESCRIPTION
状态
|:-:|
[![ci](https://github.com/frg2089/vscode-background/actions/workflows/ci.yml/badge.svg)](https://github.com/frg2089/vscode-background/actions/workflows/ci.yml)

## 功能

- ### 85903f9c080446b2a3901d39a14e67b1cc0436a9 使用[`onStartupFinished`](https://code.visualstudio.com/api/references/activation-events#onStartupFinished)代替`*`
  这个扩展或许可以等一等再加载
- ### b96cd5934eb2a70ce11985feb289beb2f4c22e71 使背景应用到“开始”页面
  #279 
- ### b96cd5934eb2a70ce11985feb289beb2f4c22e71 允许改变Minimap透明度
  #279 
  我注意到这个功能在 982b04bae24da32ca486654b1c4e6d6df334e24b 有完成过，但是在 23019e9d83598eb1f76a539f105c5b0dc512f4ac 被修改回去了
- ### 59fc89847e0f9bbe397c29056e7271d000d318d8 使”自定义图像源“设置项显示可视化编辑器
  ![image](https://user-images.githubusercontent.com/42184238/172995275-e3c0a23e-80a2-41d8-9835-1d63e440866c.png)
- ### 31cc77198bd8c5ead23794c81e149eccadce92de 设置"extensionKind"
  #156
  #157 
- ### 9a47348e5e71b6ad9d9915ecb60fead13b957490 当安装有`lehni.vscode-fix-checksums`扩展时询问是否需要使用这个扩展
  这样子的话...会方便吗...?
- ### ba5c62545327505d62fd8665d21121e9ee8cc49d 使扩展详情页可以显示背景
  ~争取让所有内置的除了webview以外的地方都能显示背景~
- ### 8ffef1572813b8e204c430c06d5b90d2ff9e4d09 提供一种更方便的扩展卸载方式
  或许这个卸载方式没有在 139fcdaa3ed66bd2fe7a7fd718d727bc653747a7 提交的方式方便
  但...有个更明显的卸载命令...或许会更好...?
  配合上请求提权功能，或许用户可以安全的在非提权的VSCode中卸载扩展...?
- ### 26f8c9a1bd4e191d34c0ba14666c093e0b4d8e96 差异编辑器应用背景图
  ~争取让所有内置的除了webview以外的地方都能显示背景~
- ### aefc940fca8a7aa46f99637f535b0c948a60228e 从设置项中读取选择器
  这样用户就可以通过改设置而不是改源代码来将背景图应用到其他地方了
- ### 26c6d07e84d5c8048d608729b9da0642c7c899b5 请求提权写入css
  这是 #180 提到的很有用的功能。
  我在Ubuntu中测试时，没法通过sudo来打开VSCode。
  这个功能可以使不需要提权整个VSCode也可以修改css文件
  它或许可以解决 #292 中提到的问题
- ### 5505e3a3eae4747d2eb76d17e1e7ebbd1772f63e 将选择器移至默认设置项中
  这一步可能不是必要的，这样会导致长时间不去写它然后忘了哪个选择器是指向哪个元素的了
  这样做的好处是用户在不希望使用这些选择器的时候可以通过修改设置来覆盖它
- ### a7b7823232f402c45243c406fb240f9e11c49463 配置自动构建ci
  这个经过修改的CI现在可以将每次push的代码生成的vsix打包供下载（nightly构建）
  其他开发者在提交PR时也可以通过CI自动构建一个扩展包用来测试功能