### PR TITLE
使扩展的发布者被修改后，卸载命令正常工作

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,12 @@ export const BACKGROUND_VER = 'background.ver';
 
 /** 文件编码 */
 export const ENCODE = 'utf-8';
+
+/** 发布者 */
+export const PUBLISHER: string = pkg.publisher;
+
+/** 扩展名 */
+export const EXTENSION_NAME: string = pkg.name;
+
+/** 扩展ID */
+export const EXTENSION_ID = `${PUBLISHER}.${EXTENSION_NAME}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import vscode from 'vscode';
 import { background } from './background';
-import { VERSION } from './constants';
+import { EXTENSION_ID, VERSION } from './constants';
 import { vsHelp } from './vsHelp';
 
 // this method is called when your extension is activated
@@ -42,7 +42,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             if (await background.uninstall()) {
                 // 当且仅当成功删除样式时才会卸载扩展
                 // 否则可能导致没有成功删掉样式时扩展就被卸载掉
-                await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', 'shalldie.background');
+                await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', EXTENSION_ID);
                 await vsHelp.showInfoRestart('background extension has been uninstalled. See you next time!');
             }
         })


### PR DESCRIPTION
应该不至于说是有人fork完自己改完之后, 卸载插件卸载的是shalldie.vscode-background 吧...