### PR TITLE
加入一点点魔法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .husky
 *.touch
 *.cache
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/sudo-prompt": "^9.3.1",
-        "lockfile": "^1.0.4"
+        "lockfile": "^1.0.4",
+        "stylis": "^4.1.3"
       },
       "devDependencies": {
         "@types/lockfile": "^1.0.2",
         "@types/node": "^16.11.45",
+        "@types/stylis": "^4.0.2",
         "@types/vscode": "^1.40.0",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
@@ -121,6 +123,12 @@
       "version": "16.11.45",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-16.11.45.tgz",
       "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+      "dev": true
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/stylis/-/stylis-4.0.2.tgz",
+      "integrity": "sha512-wtckGuk1eXUlUz0Qb1eXHG37Z7HWT2GfMdqRf8F/ifddTwadSS9Jwsqi4qtXk7cP7MtoyGVIHPElFCLc6HItbg==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -2000,6 +2008,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
@@ -2465,6 +2478,12 @@
       "version": "16.11.45",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-16.11.45.tgz",
       "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+      "dev": true
+    },
+    "@types/stylis": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/stylis/-/stylis-4.0.2.tgz",
+      "integrity": "sha512-wtckGuk1eXUlUz0Qb1eXHG37Z7HWT2GfMdqRf8F/ifddTwadSS9Jwsqi4qtXk7cP7MtoyGVIHPElFCLc6HItbg==",
       "dev": true
     },
     "@types/vscode": {
@@ -3967,6 +3986,11 @@
       "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
   "devDependencies": {
     "@types/lockfile": "^1.0.2",
     "@types/node": "^16.11.45",
+    "@types/stylis": "^4.0.2",
     "@types/vscode": "^1.40.0",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
@@ -130,7 +131,8 @@
     "vsce": "^2.9.1"
   },
   "dependencies": {
+    "@vscode/sudo-prompt": "^9.3.1",
     "lockfile": "^1.0.4",
-    "@vscode/sudo-prompt": "^9.3.1"
+    "stylis": "^4.1.3"
   }
 }

--- a/src/background/CssGenerator/CssGenerator.base.ts
+++ b/src/background/CssGenerator/CssGenerator.base.ts
@@ -9,7 +9,16 @@ import { VERSION, BACKGROUND_VER } from '../../constants';
  */
 export function css(template: TemplateStringsArray, ...args: any[]) {
     return template.reduce((prev, curr, i) => {
-        const arg = Array.isArray(args[i]) ? args[i].join('') : args[i];
+        let arg = args[i];
+
+        // 注意顺序, 内嵌函数可能返回 Array
+        if (typeof arg === 'function') {
+            arg = arg();
+        }
+        if (Array.isArray(arg)) {
+            arg = arg.join('');
+        }
+
         return prev + curr + (arg ?? '');
     }, '');
 }

--- a/src/background/CssGenerator/CssGenerator.base.ts
+++ b/src/background/CssGenerator/CssGenerator.base.ts
@@ -1,7 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
+import { compile, serialize, stringify } from 'stylis';
 import { VERSION, BACKGROUND_VER } from '../../constants';
+
+/**
+ * 用于触发开发工具 css in js 语言支持
+ */
+export function css(template: TemplateStringsArray, ...args: any[]) {
+    return template.reduce((prev, curr, i) => {
+        const arg = Array.isArray(args[i]) ? args[i].join('') : args[i];
+        return prev + curr + (arg ?? '');
+    }, '');
+}
 
 export abstract class AbsCssGenerator<T = any> {
     /**
@@ -22,19 +33,14 @@ export abstract class AbsCssGenerator<T = any> {
 
     /**
      * 图片预处理
-     *
+     * 在 v1.51.1 版本之后, vscode 将工作区放入 sandbox 中运行并添加了 file 协议的访问限制, 导致使用 file 协议的背景图片无法显示
+     * 当检测到配置文件使用 file 协议时, 需要将图片读取并转为 base64, 而后再插入到 css 中
      * @protected
      * @param {string[]} images 图片列表
      * @return {*}
      * @memberof AbsCssGenerator
      */
     protected async normalizeImages(images: string[]) {
-        /*
-          图片预处理
-          在 v1.51.1 版本之后, vscode 将工作区放入 sandbox 中运行并添加了 file 协议的访问限制, 导致使用 file 协议的背景图片无法显示
-          当检测到配置文件使用 file 协议时, 需要将图片读取并转为 base64, 而后再插入到 css 中
-        */
-
         const list: string[] = []; // 处理后的图片列表
 
         for (const url of images) {
@@ -43,6 +49,13 @@ export abstract class AbsCssGenerator<T = any> {
         }
 
         return list;
+    }
+
+    /**
+     * 编译 css
+     */
+    protected compileCSS(source: string) {
+        return serialize(compile(source), stringify);
     }
 
     protected abstract getCss(options: T): Promise<string>;

--- a/src/background/CssGenerator/CssGenerator.base.ts
+++ b/src/background/CssGenerator/CssGenerator.base.ts
@@ -63,22 +63,21 @@ export abstract class AbsCssGenerator<T = any> {
     /**
      * 编译 css
      */
-    protected compileCSS(source: string) {
+    private compileCSS(source: string) {
         return serialize(compile(source), stringify);
     }
 
     protected abstract getCss(options: T): Promise<string>;
 
     public async create(options: T) {
-        const imageStyleContent = await this.getCss(options);
+        const source = await this.getCss(options);
+        const styles = this.compileCSS(source);
 
-        const content = `
+        return `
         /*css-background-start*/
         /*${BACKGROUND_VER}.${VERSION}*/
-        ${imageStyleContent}
+        ${styles}
         /*css-background-end*/
         `;
-
-        return content;
     }
 }

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -34,19 +34,13 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
      * @memberof DefaultCssGenerator
      */
     protected getStyleByOptions(options: any, useFront: boolean): string {
-        const styleArr: string[] = [];
-        for (const k in options) {
-            // 在使用背景图时，排除掉 pointer-events
-            if (!useFront && ~['pointer-events', 'z-index'].indexOf(k)) {
-                continue;
-            }
+        // 在使用背景图时，排除掉 pointer-events 和 z-index
+        const excludeKeys = useFront ? [] : ['pointer-events', 'z-index'];
 
-            // eslint-disable-next-line
-            if (options.hasOwnProperty(k)) {
-                styleArr.push(`${k}:${options[k]}`);
-            }
-        }
-        return styleArr.join(';') + ';';
+        return Object.entries(options)
+            .filter(([key]) => !excludeKeys.includes(key))
+            .map(([key, value]) => `${key}: ${value};`)
+            .join('');
     }
 
     protected async getCss(options: DefaultGeneratorOptions) {

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -58,33 +58,27 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
         // ------ 在前景图时使用 ::after ------
         const frontContent = useFront ? 'after' : 'before';
 
-        // ------ 生成背景图片样式 ------
-        const imageStyles = images.map((image, index) => {
-            const styleContent = defStyle + this.getStyleByOptions(styles[index] || {}, useFront);
-            const nthChild = loop ? `${images.length}n + ${index + 1}` : `${index + 1}`;
-
-            return css`
-                // code editor
-                &:nth-child(${nthChild}) .editor-container .overflow-guard > .monaco-scrollable-element::${frontContent} {
-                    background-image: url('${image}');
-                    ${styleContent}
-                }
-                // home screen
-                &:nth-child(${nthChild}) .empty::before {
-                    background-image: url('${image}');
-                    ${styleContent}
-                }
-            `;
-        });
-
-        // ------ 添加最外层的选择器 ------
+        // ------ 生成样式 ------
+        // prettier-ignore
         return css`
-            [id='workbench.parts.editor'] .split-view-view {
-                ${imageStyles}
-                // 处理一块背景色遮挡 
+            [id="workbench.parts.editor"] .split-view-view {
+                // 处理一块背景色遮挡
                 .editor-container .overflow-guard > .monaco-scrollable-element > .monaco-editor-background {
                     background: none;
                 }
+                // 背景图片样式
+                ${images.map((image, index) => {
+                    const styleContent = defStyle + this.getStyleByOptions(styles[index] || {}, useFront);
+                    const nthChild = loop ? `${images.length}n + ${index + 1}` : `${index + 1}`;
+
+                    return css`
+                        &:nth-child(${nthChild}) .editor-container .overflow-guard > .monaco-scrollable-element::${frontContent},
+                        &:nth-child(${nthChild}) .empty::before {
+                            background-image: url("${image}");
+                            ${styleContent}
+                        }
+                    `
+                })}
             }
         `;
     }

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -78,7 +78,7 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
         });
 
         // ------ 添加最外层的选择器 ------
-        const source = css`
+        return css`
             [id='workbench.parts.editor'] .split-view-view {
                 ${imageStyles}
                 // 处理一块背景色遮挡 
@@ -87,7 +87,5 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
                 }
             }
         `;
-
-        return this.compileCSS(source);
     }
 }

--- a/src/background/CssGenerator/CssGenerator.fullscreen.ts
+++ b/src/background/CssGenerator/CssGenerator.fullscreen.ts
@@ -1,4 +1,4 @@
-import { AbsCssGenerator } from './CssGenerator.base';
+import { AbsCssGenerator, css } from './CssGenerator.base';
 
 /**
  * 全屏配置
@@ -21,21 +21,24 @@ export class FullScreenGeneratorOptions {
  */
 export class FullScreenCssGenerator extends AbsCssGenerator<FullScreenGeneratorOptions> {
     protected async getCss(options: FullScreenGeneratorOptions) {
-        // 处理默认参数
-        options = {
+        let { size, opacity, image } = {
             ...new FullScreenGeneratorOptions(),
             ...options
         };
 
-        options.image = (await this.normalizeImages([options.image]))[0];
+        // ------ 处理图片 ------
+        image = (await this.normalizeImages([image]))[0];
 
-        return `
-        body {
-            background-size: ${options.size};
-            background-repeat: no-repeat;
-            background-position: center;
-            opacity:${options.opacity};
-            background-image:url('${options.image}');
-        }`;
+        const styles = css`
+            body {
+                background-size: ${size};
+                background-repeat: no-repeat;
+                background-position: center;
+                opacity: ${opacity};
+                background-image: url('${image}');
+            }
+        `;
+
+        return this.compileCSS(styles);
     }
 }

--- a/src/background/CssGenerator/CssGenerator.fullscreen.ts
+++ b/src/background/CssGenerator/CssGenerator.fullscreen.ts
@@ -29,7 +29,7 @@ export class FullScreenCssGenerator extends AbsCssGenerator<FullScreenGeneratorO
         // ------ 处理图片 ------
         image = (await this.normalizeImages([image]))[0];
 
-        const styles = css`
+        return css`
             body {
                 background-size: ${size};
                 background-repeat: no-repeat;
@@ -38,7 +38,5 @@ export class FullScreenCssGenerator extends AbsCssGenerator<FullScreenGeneratorO
                 background-image: url('${image}');
             }
         `;
-
-        return this.compileCSS(styles);
     }
 }


### PR DESCRIPTION
灵感来源于 @emotion/css
目前在 webstorm 上能得到完整的支持, 在 vscode 中使用 [vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components) 能够得到一定的语法高亮. 

Todo:
- [x] css tag function 添加内嵌函数支持
- [x] 将 css 编译调整到 `AbsCssGenerator` 的 create 函数下, 减少实现类工作.
- [x] 重构样式生成部分, 寻找更优雅的写法.