### PR TITLE
Added Japanese translation, changed the name of the settings screen, and fixed a bug that caused images to appear in the search bar.

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,7 +1,7 @@
 <!-- 中英文切换 -->
 <div align="right">
 
-[English](./README.md) | [中文](./README.zh-CN.md)　| [日本語](./README.ja-JP.md)
+[English](./README.md) | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)
 
 </div>
 <!-- 中英文切换 end -->

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,0 +1,214 @@
+<!-- 中英文切换 -->
+<div align="right">
+
+[English](./README.md) | [中文](./README.zh-CN.md)　| [日本語](./README.ja-JP.md)
+
+</div>
+<!-- 中英文切换 end -->
+
+<!-- 封面区域 -->
+<div align="center">
+
+![logo](https://user-images.githubusercontent.com/9987486/40583704-6accf3a4-61c6-11e8-8c00-a636b9c3ec65.png)
+
+<h1><b>vscode-background</b></h1>
+
+### [Visual Studio Code](https://code.visualstudio.com)にも背景画像を。
+
+`エディターごとの画像表示`、`全画面の画像表示`、`画像の切り替わり`、`画像・CSSのカスタマイズ`...
+
+[GitHub](https://github.com/shalldie/vscode-background) | [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=shalldie.background)
+
+[![Version](https://img.shields.io/visual-studio-marketplace/v/shalldie.background?logo=visualstudiocode&style=flat-square)](https://marketplace.visualstudio.com/items?itemName=shalldie.background)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/shalldie.background?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=shalldie.background)
+[![Ratings](https://img.shields.io/visual-studio-marketplace/r/shalldie.background?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=shalldie.background)
+[![Stars](https://img.shields.io/github/stars/shalldie/vscode-background?logo=github&style=flat-square)](https://github.com/shalldie/vscode-background)
+[![Build Status](https://img.shields.io/github/workflow/status/shalldie/vscode-background/ci?label=build&style=flat-square)](https://github.com/shalldie/vscode-background/actions)
+[![License](https://img.shields.io/github/license/shalldie/vscode-background?style=flat-square)](https://github.com/shalldie/vscode-background)
+
+</div>
+
+<!-- 封面区域 end -->
+
+---
+
+エディターごとの画像
+
+<img width="880" src="https://user-images.githubusercontent.com/9987486/40583705-7105dda8-61c6-11e8-935a-3c5d475a1eb1.gif">
+
+背景画像の全画面表示
+
+<img width="880" src="https://user-images.githubusercontent.com/9987486/198958380-6eaf96c7-3aa2-4fce-b27e-6f33c8d4e2c1.png">
+
+## インストール
+
+サイドバーの拡張機能タブから`background`を検索！
+
+## カスタマイズ
+
+`settings.json`からユーザー設定をカスタマイズすることができます。
+
+[settings.jsonとは](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) | [設定方法](https://github.com/shalldie/vscode-background/issues/274)
+
+## コンフィグ
+
+### 基本設定
+
+| 設定                 |  タイプ   | デフォルト | 説明                                       |
+| :------------------- | :-------: | :--------: | :----------------------------------------- |
+| `background.enabled` | `Boolean` |   `true`   | 拡張機能を有効化するかどうかを制御します。 |
+
+### デフォルト設定
+
+| 設定                      |     タイプ      |  デフォルト  | 説明                                                                        |
+| :------------------------ | :-------------: | :----------: | :-------------------------------------------------------------------------- |
+| `background.useFront`     |    `Boolean`    |    `true`    | 画像を最前面に表示するかどうかを制御します。                                |
+| `background.useDefault`   |    `Boolean`    |    `true`    | デフォルトの画像を使用するかどうかを制御します。                            |
+| `background.style`        |    `Object`     |     `{}`     | 全ての画像に適応されるCSSを制御します。                                     |
+| `background.styles`       | `Array<Object>` | `[{},{},{}]` | 個別の画像に適応されるCSSを制御します。                                     |
+| `background.customImages` | `Array<String>` |     `[]`     | 画像のパスを指定してください。                                              |
+| `background.loop`         |    `Boolean`    |   `false`    | 画像をリピートするかどうかを制御します。                                    |
+| `background.interval`     |    `Number`     |     `0`      | 次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。 |
+> `CSS`について知る [css style](https://developer.mozilla.org/ja/docs/Learn/CSS/First_steps/What_is_CSS)
+
+### フルスクリーン設定
+
+> デフォルト設定を上書きする可能性があります。
+
+| 設定                    |  タイプ  | デフォルト | 説明                        |
+| :---------------------- | :------: | :--------: | :-------------------------- |
+| `background.fullscreen` | `Object` |   `null`   | Set the image to fullscreen |
+
+
+
+## 使用例
+
+1. 拡張機能を無効化する
+
+```json
+{
+  "background.enabled": false
+}
+```
+
+2. カスタムイメージを使用する
+
+ **https**通信を採用しているリンクを使用する必要があります。  
+ http通信はVSCodeにより制限されています。
+
+```json
+{
+  "background.useDefault": false,
+  "background.customImages": ["https://a.com/b.png", "file:///Users/somepath/a.jpg"]
+}
+```
+
+1. カスタムCSS - 透明度
+
+```json
+{
+  "background.style": {
+    "opacity": 0.6
+  }
+}
+```
+
+4. カスタムCSS - 画像サイズ
+
+```json
+{
+  "background.style": {
+    "background-size": "300px 460px"//"横幅 縦幅"
+  }
+}
+```
+
+5. 全画面表示
+
+```json
+{
+  "background.fullscreen": {
+    "image": "https://pathtoimage.png", // URLもしくはファイルパス(file:///~/~.png)
+    // "image": ["https://pathtoimage.png"], // 配列を使用することで複数の画像を設定できます
+    "opacity": 0.91, // 0.85 ~ 0.95 がおすすめです
+    "size": "cover", // CSSのbackground-sizeに相当します。"cover" ,"contain","200px 200px"のように設定します
+    "interval": 0 // 次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。
+  }
+}
+```
+
+## 警告
+
+> **この拡張機能は、VSCode本体のCSSファイルを編集することで機能します。**
+> そのため、初回インストール時または vscode 更新時に警告が表示されます。
+>  [二度と表示しない] をクリックして非表示にできます。
+
+![](https://user-images.githubusercontent.com/9987486/40583926-b1fb5398-61ca-11e8-8271-4ac650d158d3.png)
+
+原因:
+
+![](https://user-images.githubusercontent.com/9987486/40583775-91d4c8d6-61c7-11e8-9048-8c5538a32399.png)
+
+## アンインストール
+
+    ３つの方法
+
+    1. (おすすめ)
+
+    F1キーを押し、コマンドパネルを開ます。
+    「Background -Uninstall (remove extension)」と入力して、  
+    自動アンインストールします。
+
+    2.
+
+    setting.jsonで{"background.enabled": false}  と変更してから　　
+    手動でアンインストールします。
+
+    3. An unfriendly way:
+
+    If you uninstall this plugin directly, don't worry.
+    Exit vscode completely, then open, then reload. Now it's clean :D
+    (I know it's strange... Because of the limit of vscode)
+
+## 貢献者 🙏
+
+[<img alt="shalldie" src="https://avatars3.githubusercontent.com/u/9987486?v=4" width="80">](https://github.com/shalldie)
+[<img alt="NoDocCat" src="https://avatars.githubusercontent.com/u/20502666?v=4" width="80">](https://github.com/NoDocCat)
+[<img alt="frg2089" src="https://avatars.githubusercontent.com/u/42184238?v=4" width="80">](https://github.com/frg2089)
+[<img alt="mwSora" src="https://avatars.githubusercontent.com/u/23083011?v=4" width="80">](https://github.com/mwSora)
+[<img alt="tumit" src="https://avatars.githubusercontent.com/u/1756190?v=4" width="80">](https://github.com/tumit)
+[<img alt="asurinsaka" src="https://avatars.githubusercontent.com/u/8145535?v=4" width="80">](https://github.com/asurinsaka)
+[<img alt="u3u" src="https://avatars.githubusercontent.com/u/20062482?v=4" width="80">](https://github.com/u3u)
+[<img alt="kuresaru" src="https://avatars.githubusercontent.com/u/31172177?v=4" width="80">](https://github.com/kuresaru)
+[<img alt="Unthrottled" src="https://avatars.githubusercontent.com/u/15972415?v=4" width="80">](https://github.com/Unthrottled)
+[<img alt="rogeraabbccdd" src="https://avatars.githubusercontent.com/u/15815422?v=4" width="80">](https://github.com/rogeraabbccdd)
+
+## チェンジログ
+
+ [チェンジログ](https://github.com/shalldie/vscode-background/blob/master/CHANGELOG.md)で全ての変更を確認できます。
+
+## よくある質問
+
+---
+
+    Q: [Code インストールが壊れている可能性があります。]を消すには?
+    A: 確認してください: https://github.com/lehni/vscode-fix-checksums
+
+---
+
+    Q: MACに拡張機能をインストールしましたが、機能しません。
+    A: `Visual Studio Code` を`Download`フォルダー から`Applications`フォルダーに移動してください。
+
+---
+
+    Q: The extension runs based on the modified vscode CSS file, and will try to raise the right within a limited time.
+       If it stop working for some reason, what if users need to change their permissions?
+
+    A: In windows,click right button on the vscode's icon,then check the [run with the administrator authority].
+    A: in mac/linux, try this: https://github.com/shalldie/vscode-background/issues/6 .
+
+---
+
+## ライセンス
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 中英文切换 -->
 <div align="right">
 
-[English](./README.md) | [中文](./README.zh-CN.md)
+[English](./README.md) | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)
 
 </div>
 <!-- 中英文切换 end -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 <!-- 中英文切换 -->
 <div align="right">
 
-[English](./README.md) | [中文](./README.zh-CN.md)
+[English](./README.md) | [中文](./README.zh-CN.md)| [日本語](./README.ja-JP.md)
 
 </div>
 <!-- 中英文切换 end -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/lockfile": "^1.0.2",
         "@types/node": "^16.11.45",
         "@types/stylis": "^4.0.2",
-        "@types/vscode": "^1.40.0",
+        "@types/vscode": "^1.73.1",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
@@ -132,9 +132,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.69.0.tgz",
-      "integrity": "sha512-RlzDAnGqUoo9wS6d4tthNyAdZLxOIddLiX3djMoWk29jFfSA1yJbIwr0epBYqqYarWB6s2Z+4VaZCQ80Jaa3kA==",
+      "version": "1.73.1",
+      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.73.1.tgz",
+      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2487,9 +2487,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.69.0.tgz",
-      "integrity": "sha512-RlzDAnGqUoo9wS6d4tthNyAdZLxOIddLiX3djMoWk29jFfSA1yJbIwr0epBYqqYarWB6s2Z+4VaZCQ80Jaa3kA==",
+      "version": "1.73.1",
+      "resolved": "https://registry.npmmirror.com/@types/vscode/-/vscode-1.73.1.tgz",
+      "integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -49,22 +49,22 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Plugin background config. background 插件配置",
+      "title": "background",
       "properties": {
         "background.enabled": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Plugin background enabled.\n\nbackground 插件是否启用"
+          "markdownDescription": "Plugin background enabled.\n\nbackground 插件是否启用\n\n拡張機能の有効化"
         },
         "background.useFront": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "If use front image,which means image is placed on the top of your code.\n\n是否使用前景图，这样会使图片放在代码的顶部"
+          "markdownDescription": "If use front image,which means image is placed on the top of your code.\n\n是否使用前景图，这样会使图片放在代码的顶部\n\n画像を最前面に表示するかどうかを制御します。"
         },
         "background.useDefault": {
           "type": "boolean",
           "default": true,
-          "description": "Use default images.\n\n使用默认图片"
+          "markdownDescription": "Use default images.\n\n使用默认图片\n\nデフォルトの画像を使用するかどうか制御します。"
         },
         "background.style": {
           "type": "object",
@@ -79,7 +79,7 @@
             "background-repeat": "no-repeat",
             "opacity": 1
           },
-          "markdownDescription": "Custom common style.\n\n自定义各项公有样式."
+          "markdownDescription": "Custom common style.\n\n自定义各项公有样式.\n\n全ての画像に適応されるCSSを制御します。"
         },
         "background.styles": {
           "type": "array",
@@ -88,7 +88,7 @@
             {},
             {}
           ],
-          "markdownDescription": "Each style of backgrounds.\n\n每一个背景图的独有样式。"
+          "markdownDescription": "Each style of backgrounds.\n\n每一个背景图的独有样式\n\n個別の画像に適応されるCSSを制御します。"
         },
         "background.customImages": {
           "type": "array",
@@ -96,17 +96,17 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Your custom images. 自己定制背景图\n\nExample:\n\n`https://a.com/b.png`\n\nor\n\n`file:///a/b.jpg`"
+          "markdownDescription": "Your custom images. 自己定制背景图\n\n表示させる画像を制御します。\n\nExample:\n\n`https://a.com/b.png`\n\nor\n\n`file:///a/b.jpg`"
         },
         "background.loop": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Loop your images.\n\n循环使用图片。"
+          "markdownDescription": "Loop your images.\n\n循环使用图片。\n\n画像をループさせるかどうかを制御します。"
         },
         "background.interval": {
           "type": "number",
           "default": 0,
-          "markdownDescription": "Seconds of interval for carousel, default `0` to disabled.\n\n单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。"
+          "markdownDescription": "Seconds of interval for carousel, default `0` to disabled.\n\n单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。\n\n次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。"
         },
         "background.fullscreen": {
           "type": "object",
@@ -116,7 +116,7 @@
             "size": "cover",
             "interval": 0
           },
-          "markdownDescription": "Feature - fullscreen, may overwrite other config.\n\n全屏，会覆盖其它配置。"
+          "markdownDescription": "Feature - fullscreen, may overwrite other config.\n\n全屏，会覆盖其它配置。\n\nフルスクリーン表示の設定（他の設定を上書きする可能性があります。）"
         }
       }
     }
@@ -125,7 +125,7 @@
     "@types/lockfile": "^1.0.2",
     "@types/node": "^16.11.45",
     "@types/stylis": "^4.0.2",
-    "@types/vscode": "^1.40.0",
+    "@types/vscode": "^1.73.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/shalldie/vscode-background.git"
   },
   "engines": {
-    "vscode": "^1.40.0"
+    "vscode": "^1.73.1"
   },
   "icon": "images/logo.png",
   "categories": [
@@ -40,11 +40,11 @@
     "commands": [
       {
         "command": "extension.background.info",
-        "title": "Background - Info"
+        "title": "%extension.background.command.info.title%"
       },
       {
         "command": "extension.background.uninstall",
-        "title": "Background - Uninstall (remove extension)"
+        "title": "%extension.background.command.uninstall.title%"
       }
     ],
     "configuration": {
@@ -54,17 +54,17 @@
         "background.enabled": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Plugin background enabled.\n\nbackground 插件是否启用\n\n拡張機能の有効化"
+          "markdownDescription": "%extension.background.enabled.description%"
         },
         "background.useFront": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "If use front image,which means image is placed on the top of your code.\n\n是否使用前景图，这样会使图片放在代码的顶部\n\n画像を最前面に表示するかどうかを制御します。"
+          "markdownDescription": "%extension.background.useFront.description%"
         },
         "background.useDefault": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Use default images.\n\n使用默认图片\n\nデフォルトの画像を使用するかどうか制御します。"
+          "markdownDescription": "%extension.background.useDefault.description%"
         },
         "background.style": {
           "type": "object",
@@ -79,7 +79,7 @@
             "background-repeat": "no-repeat",
             "opacity": 1
           },
-          "markdownDescription": "Custom common style.\n\n自定义各项公有样式.\n\n全ての画像に適応されるCSSを制御します。"
+          "markdownDescription": "%extension.background.style.description%"
         },
         "background.styles": {
           "type": "array",
@@ -88,7 +88,7 @@
             {},
             {}
           ],
-          "markdownDescription": "Each style of backgrounds.\n\n每一个背景图的独有样式\n\n個別の画像に適応されるCSSを制御します。"
+          "markdownDescription": "%extension.background.styles.description%"
         },
         "background.customImages": {
           "type": "array",
@@ -96,17 +96,17 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Your custom images. 自己定制背景图\n\n表示させる画像を制御します。\n\nExample:\n\n`https://a.com/b.png`\n\nor\n\n`file:///a/b.jpg`"
+          "markdownDescription": "%extension.background.customImages.description%"
         },
         "background.loop": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Loop your images.\n\n循环使用图片。\n\n画像をループさせるかどうかを制御します。"
+          "markdownDescription": "%extension.background.loop.description%"
         },
         "background.interval": {
           "type": "number",
           "default": 0,
-          "markdownDescription": "Seconds of interval for carousel, default `0` to disabled.\n\n单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。\n\n次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。"
+          "markdownDescription": "%extension.background.interval.description%"
         },
         "background.fullscreen": {
           "type": "object",
@@ -116,7 +116,7 @@
             "size": "cover",
             "interval": 0
           },
-          "markdownDescription": "Feature - fullscreen, may overwrite other config.\n\n全屏，会覆盖其它配置。\n\nフルスクリーン表示の設定（他の設定を上書きする可能性があります。）"
+          "markdownDescription": "%extension.background.fullscreen.description%"
         }
       }
     }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,0 +1,14 @@
+{
+    "extension.background.command.info.title": "Background - 詳細情報",
+    "extension.background.command.uninstall.title": "Background - アンインストール",
+
+    "extension.background.enabled.description": "拡張機能の有効化を制御します",
+    "extension.background.useFront.description": "画像を最前面に表示するかどうかを制御します。",
+    "extension.background.useDefault.description": "デフォルトの画像を使用するかどうか制御します。",
+    "extension.background.style.description": "全ての画像に適応されるCSSを制御します。",
+    "extension.background.styles.description": "個別の画像に適応されるCSSを制御します。",
+    "extension.background.customImages.description": "表示させる画像を制御します。\n\nパスの入力例:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
+    "extension.background.loop.description": "画像をループさせるかどうかを制御します。",
+    "extension.background.interval.description": "次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。",
+    "extension.background.fullscreen.description": "フルスクリーン表示の設定（他の設定を上書きする可能性があります。）"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,14 @@
+{
+    "extension.background.command.info.title": "Background - Info",
+    "extension.background.command.uninstall.title": "Background - Uninstall",
+
+    "extension.background.enabled.description": "Plugin background enabled.",
+    "extension.background.useFront.description": "If use front image,which means image is placed on the top of your code.",
+    "extension.background.useDefault.description": "Use default images.",
+    "extension.background.style.description": "Custom common style.",
+    "extension.background.styles.description": "Each style of backgrounds.",
+    "extension.background.customImages.description": "Your custom images.\n\nExample:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
+    "extension.background.loop.description": "Loop your images.",
+    "extension.background.interval.description": "Seconds of interval for carousel, default `0` to disabled",
+    "extension.background.fullscreen.description": "Feature - fullscreen, may overwrite other config"
+}

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,0 +1,14 @@
+{
+    "extension.background.command.info.title": "Background - Info",
+    "extension.background.command.uninstall.title": "Background - Uninstall",
+
+    "extension.background.enabled.description": "background 插件是否启用",
+    "extension.background.useFront.description": "是否使用前景图，这样会使图片放在代码的顶部",
+    "extension.background.useDefault.description": "使用默认图片",
+    "extension.background.style.description": "自定义各项公有样式",
+    "extension.background.styles.description": "每一个背景图的独有样式",
+    "extension.background.customImages.description": "自己定制背景图\n\n例如:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
+    "extension.background.loop.description": "循环使用图片",
+    "extension.background.interval.description": "单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。",
+    "extension.background.fullscreen.description": "全屏，会覆盖其它配置。"
+}

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -99,7 +99,8 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
 
                     return css`
                         /* code editor */
-                        &:nth-child(${nthChild}) .editor-container .overflow-guard > .monaco-scrollable-element::${frontContent},
+                        //Although very forced, ":not([style*="height: 20px;"])" excludes the search bar.
+                        &:nth-child(${nthChild}) .editor-container .overflow-guard > .monaco-scrollable-element:not([style*="height: 20px;"])::${frontContent},
                         /* home screen */
                         &:nth-child(${nthChild}) .empty::before {
                             background-image: url('${image}');


### PR DESCRIPTION
Added Japanese translation and changed the display name of the settings screen from "Plugin background config. background 插件配置" to "background".
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/86603229/204258276-425b34bd-d5f9-486e-b7b2-d5b068ce7f81.png">

and... A bug that caused images to appear in the search bar has been **"forcefully"** fixed.
Please help me, as I'm sure this is not the right fix by any means.
[details](https://github.com/shalldie/vscode-background/commit/8e2e412b6ab0c1c2788cdbdd78a3684b439c72f3#comments)
This is my first time sending a pull request, so I apologize if it is rude or incomplete.

translation by deepL