### PR TITLE
修复在 code-server 内全屏不居中的问题 (#372)

### DIFF
--- a/src/background/CssGenerator/CssGenerator.fullscreen.ts
+++ b/src/background/CssGenerator/CssGenerator.fullscreen.ts
@@ -51,6 +51,7 @@ export class FullScreenCssGenerator extends AbsCssGenerator<FullScreenGeneratorO
             body {
                 background-size: ${size};
                 background-repeat: no-repeat;
+                background-attachment: fixed; // 兼容 code-server，其他的不影响
                 background-position: ${position};
                 opacity: ${opacity};
                 background-image: url('${images[0]}');


### PR DESCRIPTION
code server 魔改了body的样式，因此额外添加了 `background-attachment: fixed;` 进行适配