### PR TITLE
移除已弃用的配置项并优化一些提示信息

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
         "background.fullscreen": {
           "type": "object",
           "default": {
-            "image": "",
             "images": [],
             "opacity": 0.91,
             "size": "cover",
@@ -111,12 +110,6 @@
             "interval": 0
           },
           "properties": {
-            "image": {
-              "type": "string",
-              "pattern": "^(https://|file://)",
-              "patternErrorMessage": "%extension.background.urlProtocol.error%",
-              "deprecationMessage": "%extension.background.fullscreen.image.deprecation%"
-            },
             "images": {
               "type": "array",
               "default": [],

--- a/package.json
+++ b/package.json
@@ -66,14 +66,8 @@
         "background.style": {
           "type": "object",
           "default": {
-            "content": "''",
-            "pointer-events": "none",
-            "position": "absolute",
-            "z-index": "99",
-            "width": "100%",
-            "height": "100%",
             "background-position": "100% 100%",
-            "background-repeat": "no-repeat",
+            "background-size": "auto",
             "opacity": 1
           },
           "markdownDescription": "%extension.background.style.description%"

--- a/package.json
+++ b/package.json
@@ -101,12 +101,6 @@
           },
           "markdownDescription": "%extension.background.customImages.description%"
         },
-        "background.loop": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "%extension.background.loop.description%",
-          "deprecationMessage": "%extension.background.common.deprecation%"
-        },
         "background.interval": {
           "type": "number",
           "default": 0,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
             "content": "''",
             "pointer-events": "none",
             "position": "absolute",
-            "z-index": "99999",
+            "z-index": "99",
             "width": "100%",
             "height": "100%",
             "background-position": "100% 100%",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "commands": [
       {
         "command": "extension.background.info",
+        "category": "Background",
         "title": "%extension.background.command.info.title%"
       },
       {
         "command": "extension.background.uninstall",
+        "category": "Background",
         "title": "%extension.background.command.uninstall.title%"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -61,12 +61,6 @@
           "default": true,
           "markdownDescription": "%extension.background.useFront.description%"
         },
-        "background.useDefault": {
-          "type": "boolean",
-          "default": null,
-          "markdownDescription": "%extension.background.useDefault.description%",
-          "deprecationMessage": "%extension.background.common.deprecation%"
-        },
         "background.style": {
           "type": "object",
           "default": {

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,6 +1,6 @@
 {
-    "extension.background.command.info.title": "Background - 詳細情報",
-    "extension.background.command.uninstall.title": "Background - アンインストール",
+    "extension.background.command.info.title": "詳細情報を見て",
+    "extension.background.command.uninstall.title": "拡張機能をアンインストール",
 
     "extension.background.enabled.description": "拡張機能の有効化を制御します",
     "extension.background.useFront.description": "画像を最前面に表示するかどうかを制御します。",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -10,7 +10,6 @@
     "extension.background.interval.description": "次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。",
 
     "extension.background.fullscreen.description": "フルスクリーン表示の設定（他の設定を上書きする可能性があります。）",
-    "extension.background.fullscreen.image.deprecation": "廃止する。「images」に変更してください",
 
     "extension.background.common.deprecation": "次のバージョンでは削除される予定です。この設定項目を削除してください",
     "extension.background.urlProtocol.error": "画像パスには https または file プロトコルを使用する必要があります"

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -4,7 +4,6 @@
 
     "extension.background.enabled.description": "拡張機能の有効化を制御します",
     "extension.background.useFront.description": "画像を最前面に表示するかどうかを制御します。",
-    "extension.background.useDefault.description": "デフォルトの画像を使用するかどうか制御します。",
     "extension.background.style.description": "全ての画像に適応されるCSSを制御します。",
     "extension.background.styles.description": "個別の画像に適応されるCSSを制御します。",
     "extension.background.customImages.description": "表示させる画像を制御します。\n\nパスの入力例:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -8,7 +8,6 @@
     "extension.background.style.description": "全ての画像に適応されるCSSを制御します。",
     "extension.background.styles.description": "個別の画像に適応されるCSSを制御します。",
     "extension.background.customImages.description": "表示させる画像を制御します。\n\nパスの入力例:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
-    "extension.background.loop.description": "画像をループさせるかどうかを制御します。",
     "extension.background.interval.description": "次の画像を表示するまでの秒数を制御します。`0`の場合、画像は変更されません。",
 
     "extension.background.fullscreen.description": "フルスクリーン表示の設定（他の設定を上書きする可能性があります。）",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,7 +10,6 @@
     "extension.background.interval.description": "Seconds of interval for carousel, default `0` to disabled",
 
     "extension.background.fullscreen.description": "Feature - fullscreen, may overwrite other config",
-    "extension.background.fullscreen.image.deprecation": "Deprecated, use `images` instead",
 
     "extension.background.common.deprecation": "It will be removed in the next version, please delete this configuration item",
     "extension.background.urlProtocol.error": "The image url must use https or file protocol"

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
-    "extension.background.command.info.title": "Background - Info",
-    "extension.background.command.uninstall.title": "Background - Uninstall",
+    "extension.background.command.info.title": "View plugin info",
+    "extension.background.command.uninstall.title": "Uninstall plugin",
 
     "extension.background.enabled.description": "Plugin background enabled.",
     "extension.background.useFront.description": "If use front image,which means image is placed on the top of your code.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,7 +8,6 @@
     "extension.background.style.description": "Custom common style.",
     "extension.background.styles.description": "Each style of backgrounds.",
     "extension.background.customImages.description": "Your custom images.\n\nExample:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
-    "extension.background.loop.description": "Loop your images.",
     "extension.background.interval.description": "Seconds of interval for carousel, default `0` to disabled",
 
     "extension.background.fullscreen.description": "Feature - fullscreen, may overwrite other config",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,7 +4,6 @@
 
     "extension.background.enabled.description": "Plugin background enabled.",
     "extension.background.useFront.description": "If use front image,which means image is placed on the top of your code.",
-    "extension.background.useDefault.description": "Use default images.",
     "extension.background.style.description": "Custom common style.",
     "extension.background.styles.description": "Each style of backgrounds.",
     "extension.background.customImages.description": "Your custom images.\n\nExample:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -4,7 +4,6 @@
 
     "extension.background.enabled.description": "Plugin de background habilitado",
     "extension.background.useFront.description": "Caso utilize este parametro, significa que a imagem ficará por cima de seu codigo",
-    "extension.background.useDefault.description": "Utiliza as imagens padrão",
     "extension.background.style.description": "Estilo comum personalizado",
     "extension.background.styles.description": "Cada estilo dos backgrounds",
     "extension.background.customImages.description": "Suas imagens personalizadas.\n\nExemplo:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -10,7 +10,6 @@
     "extension.background.interval.description": "Segundos de intervalo do carousel, utilize o padrão `0` para desabilitar",
 
     "extension.background.fullscreen.description": "Funcionalidade - fullscreen, pode sobrescrever as outras configurações",
-    "extension.background.fullscreen.image.deprecation": "Obsoleto, use `images` em vez disso",
 
     "extension.background.common.deprecation": "Ele será removido na próxima versão, exclua este item de configuração",
     "extension.background.urlProtocol.error": "O caminho da imagem deve usar https ou protocolo de file"

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -1,6 +1,6 @@
 {
-    "extension.background.command.info.title": "Background - Info",
-    "extension.background.command.uninstall.title": "Background - Desinstalação",
+    "extension.background.command.info.title": "Ver informações do plugin",
+    "extension.background.command.uninstall.title": "Desinstalar plugin",
 
     "extension.background.enabled.description": "Plugin de background habilitado",
     "extension.background.useFront.description": "Caso utilize este parametro, significa que a imagem ficará por cima de seu codigo",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -8,7 +8,6 @@
     "extension.background.style.description": "Estilo comum personalizado",
     "extension.background.styles.description": "Cada estilo dos backgrounds",
     "extension.background.customImages.description": "Suas imagens personalizadas.\n\nExemplo:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
-    "extension.background.loop.description": "Faça um Loop de suas imagens",
     "extension.background.interval.description": "Segundos de intervalo do carousel, utilize o padrão `0` para desabilitar",
 
     "extension.background.fullscreen.description": "Funcionalidade - fullscreen, pode sobrescrever as outras configurações",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,6 +1,6 @@
 {
-    "extension.background.command.info.title": "Background - Info",
-    "extension.background.command.uninstall.title": "Background - Uninstall",
+    "extension.background.command.info.title": "查看插件信息",
+    "extension.background.command.uninstall.title": "卸载插件",
 
     "extension.background.enabled.description": "background 插件是否启用",
     "extension.background.useFront.description": "是否使用前景图，这样会使图片放在代码的顶部",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -10,7 +10,6 @@
     "extension.background.interval.description": "单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。",
 
     "extension.background.fullscreen.description": "全屏，会覆盖其它配置。",
-    "extension.background.fullscreen.image.deprecation": "已弃用，请使用 `images` 代替。",
 
     "extension.background.common.deprecation": "将在下个版本移除, 请删除此配置项",
     "extension.background.urlProtocol.error": "图片路径必须使用 https 或者 file 协议"

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -8,7 +8,6 @@
     "extension.background.style.description": "自定义各项公有样式",
     "extension.background.styles.description": "每一个背景图的独有样式",
     "extension.background.customImages.description": "自己定制背景图\n\n例如:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",
-    "extension.background.loop.description": "循环使用图片",
     "extension.background.interval.description": "单位 `秒`，轮播时候图片切换间隔，默认 `0` 表示不开启。",
 
     "extension.background.fullscreen.description": "全屏，会覆盖其它配置。",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -4,7 +4,6 @@
 
     "extension.background.enabled.description": "background 插件是否启用",
     "extension.background.useFront.description": "是否使用前景图，这样会使图片放在代码的顶部",
-    "extension.background.useDefault.description": "使用默认图片",
     "extension.background.style.description": "自定义各项公有样式",
     "extension.background.styles.description": "每一个背景图的独有样式",
     "extension.background.customImages.description": "自己定制背景图\n\n例如:\n\n`https://a.com/b.png`\n\n`file:///a/b.jpg`",

--- a/src/background/Background.ts
+++ b/src/background/Background.ts
@@ -106,15 +106,6 @@ export class Background implements Disposable {
         // 3.保存当前配置
         this.config = config; // 更新配置
 
-        // 处理 useDefault 默认值, 如果用户没有配置图片则开启它
-        if (config.useDefault === null) {
-            config.useDefault = !(
-                config.customImages.length ||
-                config.fullscreen?.image?.length ||
-                config.fullscreen?.images?.length
-            );
-        }
-
         // 4.如果关闭插件
         if (!config.enabled) {
             await this.uninstall();

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -107,7 +107,7 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
                         /* code editor */
                         &:nth-child(${nthChild}) .editor-instance>.monaco-editor .overflow-guard > .monaco-scrollable-element::${frontContent},
                         /* home screen */
-                        &:nth-child(${nthChild}) .empty::before {
+                        &:nth-child(${nthChild}) .editor-group-container.empty::before {
                             background-image: url('${image}');
                             ${styleContent}
                             ${this.getCarouselCss(images, interval, index)}

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -100,7 +100,14 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
                         &:nth-child(${nthChild}) .editor-instance>.monaco-editor .overflow-guard > .monaco-scrollable-element::${frontContent},
                         /* home screen */
                         &:nth-child(${nthChild}) .editor-group-container.empty::before {
+                            content: '';
+                            width: 100%;
+                            height: 100%;
+                            position: absolute;
+                            z-index: ${useFront ? 99 : 'initial'};
+                            pointer-events: ${useFront ? 'none' : 'initial'};
                             background-image: url('${image}');
+                            background-repeat: no-repeat;
                             ${styleContent}
                             ${this.getCarouselCss(images, interval, index)}
                         }

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -9,10 +9,6 @@ import { AbsCssGenerator, css } from './CssGenerator.base';
  */
 export class DefaultGeneratorOptions {
     useFront = true;
-    /**
-     * @deprecated
-     */
-    useDefault = true;
     style: any = {};
     styles: Array<any> = [];
     customImages: string[] = [];
@@ -73,13 +69,13 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
     }
 
     protected async getCss(options: DefaultGeneratorOptions) {
-        const { useDefault, customImages, style, styles, useFront, interval } = {
+        const { customImages, style, styles, useFront, interval } = {
             ...new DefaultGeneratorOptions(),
             ...options
         };
 
         // ------ 处理图片 ------
-        const images = this.normalizeImageUrls(useDefault ? defBase64 : customImages);
+        const images = customImages.length ? this.normalizeImageUrls(customImages) : defBase64;
 
         // ------ 默认样式 ------
         const defStyle = this.getStyleByOptions(style, useFront);

--- a/src/background/CssGenerator/CssGenerator.default.ts
+++ b/src/background/CssGenerator/CssGenerator.default.ts
@@ -16,10 +16,6 @@ export class DefaultGeneratorOptions {
     style: any = {};
     styles: Array<any> = [];
     customImages: string[] = [];
-    /**
-     * @deprecated
-     */
-    loop = false;
     interval = 0;
 }
 
@@ -77,7 +73,7 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
     }
 
     protected async getCss(options: DefaultGeneratorOptions) {
-        const { useDefault, customImages, style, styles, useFront, loop, interval } = {
+        const { useDefault, customImages, style, styles, useFront, interval } = {
             ...new DefaultGeneratorOptions(),
             ...options
         };
@@ -101,7 +97,7 @@ export class DefaultCssGenerator extends AbsCssGenerator<DefaultGeneratorOptions
                 // 背景图片样式
                 ${images.map((image, index) => {
                     const styleContent = defStyle + this.getStyleByOptions(styles[index] || {}, useFront);
-                    const nthChild = loop ? `${images.length}n + ${index + 1}` : `${index + 1}`;
+                    const nthChild = `${images.length}n + ${index + 1}`;
 
                     return css`
                         /* code editor */

--- a/src/background/CssGenerator/CssGenerator.fullscreen.ts
+++ b/src/background/CssGenerator/CssGenerator.fullscreen.ts
@@ -13,12 +13,6 @@ const BODY_SELECTOR = parseFloat(vscode.version) >= 1.78 ? `body:has([id='workbe
 export class FullScreenGeneratorOptions {
     /**
      * 图片
-     * @deprecated
-     * @memberof FullScreenGeneratorOptions
-     */
-    image = '' as string | string[];
-    /**
-     * 图片
      * @memberof FullScreenGeneratorOptions
      */
     images = [] as string[];
@@ -53,21 +47,13 @@ export class FullScreenCssGenerator extends AbsCssGenerator<FullScreenGeneratorO
     }
 
     protected async getCss(options: FullScreenGeneratorOptions) {
-        const { size, position, opacity, image, images, interval } = {
+        const { size, position, opacity, images, interval } = {
             ...new FullScreenGeneratorOptions(),
             ...options
         };
 
         // ------ 处理图片 ------
-        const allImages = images.slice();
-        // 兼容下 image 字段
-        if (Array.isArray(image)) {
-            allImages.push(...image);
-        }
-        if (typeof image === 'string' && image.length) {
-            allImages.push(image);
-        }
-        const nextImages = this.normalizeImageUrls(allImages);
+        const nextImages = this.normalizeImageUrls(images);
 
         return css`
             ${BODY_SELECTOR} {

--- a/src/background/CssGenerator/index.ts
+++ b/src/background/CssGenerator/index.ts
@@ -17,7 +17,7 @@ export type TCssGeneratorOptions = DefaultGeneratorOptions & {
  */
 export class CssGenerator {
     public static create(options: TCssGeneratorOptions) {
-        if (options.fullscreen?.image?.length || options.fullscreen?.images?.length) {
+        if (options.fullscreen?.images?.length) {
             return new FullScreenCssGenerator().create(options.fullscreen);
         }
 


### PR DESCRIPTION
## 检查清单

- [x] 阅读 [贡献指南](https://github.com/shalldie/vscode-background/blob/master/CONTRIBUTING.zh-CN.md)。
- [x] 把 issue 和 pr 相关联.
- [x] 确保代码与 `master` 分支保持同步.
- [x] 尽可能详细的描述所做的变更.

## 内容摘要

1. 修复了 #416 中报告的样式泄露问题
2. 验证并合并了 #413 中修复背景图异常遮盖问题的代码
3. 移除了在 #399 中弃用的配置项（loop, useDefault, fullscreen.image）
4. 优化了命令面板提示信息，现在效果如图所示：
![image](https://github.com/shalldie/vscode-background/assets/20502666/ac603b38-6f9a-4319-961d-9bb34903c0da)
5. 优化了 style 配置项的默认值，现在仅为用户提示常用的 css 样式配置，以防止意外修改造成的问题：
![image](https://github.com/shalldie/vscode-background/assets/20502666/5686dbef-454b-41a8-a78a-b41e052f1cd8)

## Todo

- [ ] @frg2089 在 #325 中实现过用文件的形式提供默认图片，与 base64 相比能减少图片的体积并提升可维护性，这个改动是否要添加到这个版本中？
- [ ] 需要将 @0x-jerry 添加到贡献者列表中。另外，当前贡献者列表中的部分贡献者信息和链接已失效需要更新，是否应考虑添加 [AllContributors](https://github.com/apps/allcontributors) 之类的 bot 来自动更新

