### PR TITLE
fix: vscode base dir

### DIFF
--- a/src/utils/vscodePath.ts
+++ b/src/utils/vscodePath.ts
@@ -1,8 +1,15 @@
 import path from 'path';
 import { vscode } from './vsc';
 
+const getBase = () => {
+    const mainFilename = require.main?.filename;
+    const vscodeInstallPath = vscode?.env.appRoot;
+    const base = mainFilename?.length ? path.dirname(mainFilename) : path.join(vscodeInstallPath!, 'out');
+    return base;
+};
+
 // 基础目录
-const base = path.dirname(require.main!.filename);
+const base = getBase();
 
 // css文件路径
 const cssName = 'workbench.desktop.main.css';


### PR DESCRIPTION
close #465, close #459

vscode 切换 esm 架构了， `require` 不可用了。