### PR TITLE
fix: add patch lockfile for multiple instances

### DIFF
--- a/src/background/Background.ts
+++ b/src/background/Background.ts
@@ -4,7 +4,6 @@ import path from 'path';
 
 import vscode, { Disposable, l10n, Uri } from 'vscode';
 
-import { utils } from '../utils';
 import { ENCODING, EXTENSION_NAME, TOUCH_JSFILE_PATH, VERSION } from '../utils/constants';
 import { vscodePath } from '../utils/vscodePath';
 import { vsHelp } from '../utils/vsHelp';
@@ -19,6 +18,7 @@ type TConfigType = vscode.WorkspaceConfiguration & TPatchGeneratorConfig;
 
 /**
  * 插件逻辑类
+ * Extension logic
  *
  * @export
  * @class Background
@@ -36,6 +36,7 @@ export class Background implements Disposable {
     public jsFile = new JsPatchFile(vscodePath.jsPath);
 
     /**
+     * Current config
      * 当前用户配置
      *
      * @private
@@ -219,10 +220,6 @@ export class Background implements Disposable {
                 if (!hasChanged) {
                     return;
                 }
-
-                // 50~550ms 的延时，对于可能的多实例，错开对于文件的操作
-                // 虽然有锁了，但这样更安心 =。=
-                await utils.sleep(50 + ~~(Math.random() * 500));
 
                 this.onConfigChange();
             })

--- a/src/background/CssFile.ts
+++ b/src/background/CssFile.ts
@@ -8,7 +8,7 @@ import fs, { constants as fsConstants } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 
-import { utils } from '../utils';
+import { _ } from '../utils';
 import { BACKGROUND_VER, ENCODING, VERSION } from '../utils/constants';
 import { vsc } from '../utils/vsc';
 
@@ -116,7 +116,7 @@ export class CssFile {
             try {
                 const mvcmd = process.platform === 'win32' ? 'move /Y' : 'mv -f';
                 const cmdarg = `${mvcmd} "${tempFilePath}" "${this.filePath}"`;
-                await utils.sudoExec(cmdarg, { name: 'Visual Studio Code Background Extension' });
+                await _.sudoExec(cmdarg, { name: 'Visual Studio Code Background Extension' });
                 return true;
             } catch (e: any) {
                 await vsc.window.showErrorMessage(e.message);
@@ -177,7 +177,7 @@ export class CssFile {
      */
     public async uninstall(): Promise<boolean> {
         try {
-            await utils.lock();
+            await _.lock();
             let content = await this.getContent();
             content = this.clearContent(content);
             // 异常case return
@@ -189,7 +189,7 @@ export class CssFile {
             console.log(ex);
             return false;
         } finally {
-            await utils.unlock();
+            await _.unlock();
         }
     }
 }

--- a/src/background/PatchFile/PatchFile.base.ts
+++ b/src/background/PatchFile/PatchFile.base.ts
@@ -3,7 +3,7 @@ import fs, { constants as fsConstants } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 
-import { utils } from '../../utils';
+import { _ } from '../../utils';
 import { BACKGROUND_VER, ENCODING, VERSION } from '../../utils/constants';
 import { vsc } from '../../utils/vsc';
 
@@ -96,7 +96,7 @@ export abstract class AbsPatchFile {
             try {
                 const mvcmd = process.platform === 'win32' ? 'move /Y' : 'mv -f';
                 const cmdarg = `${mvcmd} "${tempFilePath}" "${filePath}"`;
-                await utils.sudoExec(cmdarg, { name: 'Background Extension' });
+                await _.sudoExec(cmdarg, { name: 'Background Extension' });
                 return true;
             } catch (e: any) {
                 vsc.window.showErrorMessage(e.message, { title: 'Common Issue' }).then(confirm => {
@@ -145,11 +145,11 @@ export abstract class AbsPatchFile {
     protected abstract cleanPatches(content: string): string;
 
     public async restore() {
-        await utils.lock();
+        await _.lock();
         let content = await this.getContent();
         content = this.cleanPatches(content);
         const ok = await this.write(content);
-        await utils.unlock();
+        await _.unlock();
         return ok;
     }
 }

--- a/src/background/PatchFile/PatchFile.base.ts
+++ b/src/background/PatchFile/PatchFile.base.ts
@@ -145,11 +145,15 @@ export abstract class AbsPatchFile {
     protected abstract cleanPatches(content: string): string;
 
     public async restore() {
-        await _.lock();
-        let content = await this.getContent();
-        content = this.cleanPatches(content);
-        const ok = await this.write(content);
-        await _.unlock();
-        return ok;
+        try {
+            await _.lock();
+            let content = await this.getContent();
+            content = this.cleanPatches(content);
+            return await this.write(content);
+        } catch {
+            return false;
+        } finally {
+            await _.unlock();
+        }
     }
 }

--- a/src/background/PatchFile/PatchFile.javascript.ts
+++ b/src/background/PatchFile/PatchFile.javascript.ts
@@ -1,3 +1,4 @@
+import { _ } from '../../utils';
 import { BACKGROUND_VER, VERSION } from '../../utils/constants';
 import { AbsPatchFile } from './PatchFile.base';
 
@@ -13,16 +14,23 @@ import { AbsPatchFile } from './PatchFile.base';
  */
 export class JsPatchFile extends AbsPatchFile {
     public async applyPatches(patchContent: string): Promise<boolean> {
-        let content = await this.getContent();
-        content = this.cleanPatches(content);
-        content += [
-            //
-            `\n// vscode-background-start ${BACKGROUND_VER}.${VERSION}`,
-            patchContent,
-            '// vscode-background-end'
-        ].join('\n');
+        try {
+            await _.lock();
+            let content = await this.getContent();
+            content = this.cleanPatches(content);
+            content += [
+                //
+                `\n// vscode-background-start ${BACKGROUND_VER}.${VERSION}`,
+                patchContent,
+                '// vscode-background-end'
+            ].join('\n');
 
-        return this.write(content);
+            return await this.write(content);
+        } catch {
+            return false;
+        } finally {
+            await _.unlock();
+        }
     }
 
     protected cleanPatches(content: string): string {

--- a/src/background/PatchFile/PatchFile.javascript.ts
+++ b/src/background/PatchFile/PatchFile.javascript.ts
@@ -16,14 +16,19 @@ export class JsPatchFile extends AbsPatchFile {
     public async applyPatches(patchContent: string): Promise<boolean> {
         try {
             await _.lock();
-            let content = await this.getContent();
-            content = this.cleanPatches(content);
+            const curContent = await this.getContent();
+            let content = this.cleanPatches(curContent);
             content += [
                 //
                 `\n// vscode-background-start ${BACKGROUND_VER}.${VERSION}`,
                 patchContent,
                 '// vscode-background-end'
             ].join('\n');
+
+            // file unchanged
+            if (curContent === content) {
+                return true;
+            }
 
             return await this.write(content);
         } catch {

--- a/src/background/PatchGenerator/PatchGenerator.base.ts
+++ b/src/background/PatchGenerator/PatchGenerator.base.ts
@@ -1,7 +1,7 @@
 import * as stylis from 'stylis';
 import vscode from 'vscode';
 
-import { utils } from '../../utils';
+import { _ } from '../../utils';
 
 /**
  * 用于触发开发工具 css in js 语言支持
@@ -126,7 +126,7 @@ container.appendChild(div);
             script
         ]
             .filter(n => !!n.length)
-            .map(n => utils.withIIFE(n))
+            .map(n => _.withIIFE(n))
             .join(';');
     }
 }

--- a/src/background/PatchGenerator/index.ts
+++ b/src/background/PatchGenerator/index.ts
@@ -1,6 +1,6 @@
 import uglifyjs from 'uglify-js';
 
-import { utils } from '../../utils';
+import { _ } from '../../utils';
 import { ChecksumsPatchGenerator } from './PatchGenerator.checksums';
 import {
     EditorPatchGenerator,
@@ -28,7 +28,7 @@ export class PatchGenerator {
             new PanelPatchGenerator(options.panel).create(), // panel
             new FullscreenPatchGenerator(options.fullscreen).create() // fullscreen
         ]
-            .map(n => utils.withIIFE(n))
+            .map(n => _.withIIFE(n))
             .join(';');
 
         // return script;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -43,8 +43,9 @@ export namespace _ {
             lockfile.lock(
                 LOCK_PATH,
                 {
-                    wait: 1000,
-                    retries: 3
+                    // When multiple VSCode instances are running, all instances' commands need to be executed within the `wait` time
+                    // 在打开了多个vscode实例时，需要所有实例的命令在`wait`时间内执行完毕
+                    wait: 1000 * 30
                 },
                 err => {
                     if (err) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,7 +4,7 @@ import lockfile from 'lockfile';
 import { LOCK_PATH } from './constants';
 import { vsc } from './vsc';
 
-export namespace utils {
+export namespace _ {
     /**
      * if zh-CN
      */
@@ -43,7 +43,8 @@ export namespace utils {
             lockfile.lock(
                 LOCK_PATH,
                 {
-                    wait: 5000 // 应该能撑200的并发了，，，>_<#@!
+                    wait: 1000,
+                    retries: 3
                 },
                 err => {
                     if (err) {

--- a/src/utils/vscodePath.ts
+++ b/src/utils/vscodePath.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { utils } from './index';
+import { _ } from './index';
 import { vsc } from './vsc';
 
 // 基础目录
@@ -18,7 +18,7 @@ const cssPath = (() => {
     // https://github.com/microsoft/vscode/pull/141263
     const webPath = getCssPath('workbench.web.main.css');
 
-    if (utils.isDesktop) {
+    if (_.isDesktop) {
         return defPath;
     }
     return webPath;
@@ -29,7 +29,7 @@ const jsPath = (() => {
 
     // desktop
     // /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js
-    if (utils.isDesktop) {
+    if (_.isDesktop) {
         return path.join(base, 'vs/workbench/workbench.desktop.main.js');
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request. Please select a list to check:
感谢提交pr，请选择一个checklist进行检查：
-->

### Checklist - zh-CN

- [x] 阅读 [贡献指南](https://github.com/shalldie/vscode-background/blob/master/docs/contributing.zh-CN.md)。
- [x] 把 issue 和 pr 相关联.
- [x] 确保代码与 `master` 分支保持同步.
- [x] 尽可能详细的描述所做的变更.

在存在多个实例（窗口）运行时，在 `更新vscode`、`初次安装background` 会造成同时写入同一个文件的case。
在窗口越多、安装插件越多时，发生概率越大。

添加了文件锁避免这种情况，所有实例命令在 `1000s * 30` 内执行完毕不会发生竞态。
... 但也存在极端情况，比如开了几十个窗口，又装了几十个插件，最后又运行在一个性能不太好的机器上 =。=