### PR TITLE
fix: support electron-sandbox path for Cursor/VSCode compatibility

### DIFF
--- a/src/utils/vscodePath.ts
+++ b/src/utils/vscodePath.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 
 import { _ } from './index';
@@ -27,7 +28,10 @@ const jsPath = (() => {
 
 const workbenchHtmlPath = (() => {
     if (_.isDesktop) {
-        return path.join(base, 'vs/code/electron-browser/workbench/workbench.html');
+        // new version Cursor/VSCode use electron-sandbox, old version use electron-browser
+        const sandboxPath = path.join(base, 'vs/code/electron-sandbox/workbench/workbench.html');
+        const browserPath = path.join(base, 'vs/code/electron-browser/workbench/workbench.html');
+        return fs.existsSync(sandboxPath) ? sandboxPath : browserPath;
     }
     // code-server / web
     return path.join(base, 'vs/code/browser/workbench/workbench.html');


### PR DESCRIPTION
### Checklist - en

- [x] Read our [Contributing Guide](https://github.com/shalldie/vscode-background/blob/master/docs/contributing.md).
- [x] Associate an issue with the Pull Request.
- [x] Ensure that the code is up-to-date with the `master` branch.
- [x] Include a description of the proposed changes.

### Checklist - zh-CN

- [x] 阅读 [贡献指南](https://github.com/shalldie/vscode-background/blob/master/docs/contributing.zh-CN.md)。
- [x] 把 issue 和 pr 相关联.
- [x] 确保代码与 `master` 分支保持同步.
- [x] 尽可能详细的描述所做的变更.

---



## Problem / 问题

Cursor 3.x and newer versions of VSCode have migrated the internal workbench directory from `electron-browser` to `electron-sandbox`. The hardcoded `electron-browser` path in `src/utils/vscodePath.ts` causes the extension to fail on activation with:

```
ENOENT: no such file or directory,
open '.../vs/code/electron-browser/workbench/workbench.html'
```

This results in all background commands being unregistered (`command 'extension.background.install' not found`).

Cursor 3.x 及新版 VSCode 已将内部目录从 `electron-browser` 迁移为 `electron-sandbox`，导致插件激活时找不到 `workbench.html`，所有命令均无法注册。

## Root Cause / 根本原因

`src/utils/vscodePath.ts` hardcodes the `electron-browser` path which no longer exists in Cursor 3.x (confirmed on darwin arm64).

## Fix / 修复方案

Use `fs.existsSync` to detect the path at runtime: prefer `electron-sandbox` (new), fall back to `electron-browser` (old). This maintains full backward compatibility with older VSCode versions and code-server.

运行时检测路径是否存在，优先使用 `electron-sandbox`，回退到 `electron-browser`，完全兼容旧版本。

## Changes / 变更内容

- `src/utils/vscodePath.ts`: runtime path detection instead of hardcoded `electron-browser`



## Environment / 测试环境


|           | Version                   |
| --------- | ------------------------- |
| Cursor    | 3.10.11                   |
| macOS     | darwin 25.2.0 (arm64)     |
| Extension | shalldie.background 2.1.1 |




## Related Issues / 相关 Issue

Closes #613