### PR TITLE
fix: avoid corrupting CSP directives when injecting inline script support

### DIFF
--- a/src/background/PatchFile/PatchFile.html.ts
+++ b/src/background/PatchFile/PatchFile.html.ts
@@ -2,27 +2,13 @@ import { BACKGROUND_VER, VERSION } from '../../utils/constants';
 import { AbsPatchFile } from './PatchFile.base';
 
 export class HtmlPatchFile extends AbsPatchFile {
-    private enableInlineScriptInCsp(content: string): string {
-        return content.replace(/(script-src(?!-)\s*)([\s\S]*?;)/, (match, prefix, directiveBody) => {
-            if (directiveBody.includes("'unsafe-inline'")) {
-                return match;
-            }
-
-            return `${prefix}'unsafe-inline'\n${directiveBody}`;
-        });
-    }
-
-    private disableInjectedInlineScriptInCsp(content: string): string {
-        return content.replace(/(script-src(?!-)\s*)'unsafe-inline'\s*/g, '$1');
-    }
-
     public async applyPatches(patchContent: string): Promise<boolean> {
         try {
             const curContent = await this.getContent();
             let content = this.cleanPatches(curContent);
 
             // workbench.html 的 CSP 默认不含 'unsafe-inline'，内联 script 会被拦截，需主动注入
-            content = this.enableInlineScriptInCsp(content);
+            content = content.replace(/(script-src)(\s)/, `$1 'unsafe-inline'$2`);
 
             // 将 patch 脚本内联到 HTML
             content = content.replace(
@@ -47,7 +33,7 @@ export class HtmlPatchFile extends AbsPatchFile {
 
     protected cleanPatches(content: string): string {
         // 精确逆向匹配，只移除注入的那个 'unsafe-inline'
-        content = this.disableInjectedInlineScriptInCsp(content);
+        content = content.replace(/(script-src) 'unsafe-inline'/, '$1');
         // 清除内联 script 块
         content = content.replace(
             //

--- a/src/background/PatchFile/PatchFile.html.ts
+++ b/src/background/PatchFile/PatchFile.html.ts
@@ -2,13 +2,27 @@ import { BACKGROUND_VER, VERSION } from '../../utils/constants';
 import { AbsPatchFile } from './PatchFile.base';
 
 export class HtmlPatchFile extends AbsPatchFile {
+    private enableInlineScriptInCsp(content: string): string {
+        return content.replace(/(script-src(?!-)\s*)([\s\S]*?;)/, (match, prefix, directiveBody) => {
+            if (directiveBody.includes("'unsafe-inline'")) {
+                return match;
+            }
+
+            return `${prefix}'unsafe-inline'\n${directiveBody}`;
+        });
+    }
+
+    private disableInjectedInlineScriptInCsp(content: string): string {
+        return content.replace(/(script-src(?!-)\s*)'unsafe-inline'\s*/g, '$1');
+    }
+
     public async applyPatches(patchContent: string): Promise<boolean> {
         try {
             const curContent = await this.getContent();
             let content = this.cleanPatches(curContent);
 
             // workbench.html 的 CSP 默认不含 'unsafe-inline'，内联 script 会被拦截，需主动注入
-            content = content.replace(/(script-src)/, `$1 'unsafe-inline'`);
+            content = this.enableInlineScriptInCsp(content);
 
             // 将 patch 脚本内联到 HTML
             content = content.replace(
@@ -33,7 +47,7 @@ export class HtmlPatchFile extends AbsPatchFile {
 
     protected cleanPatches(content: string): string {
         // 精确逆向匹配，只移除注入的那个 'unsafe-inline'
-        content = content.replace(/(script-src) 'unsafe-inline'/, '$1');
+        content = this.disableInjectedInlineScriptInCsp(content);
         // 清除内联 script 块
         content = content.replace(
             //


### PR DESCRIPTION
## Summary

This PR fixes a small CSP patching bug in `src/background/PatchFile/PatchFile.html.ts`.

When injecting `'unsafe-inline'` into the `script-src` directive, the previous implementation matched the first `script-src` substring too loosely. In cases where a CSP contains directives such as `script-src-elem`, that replacement could corrupt the directive name instead of updating the actual `script-src` directive.

This change narrows the replacement to the real `script-src` directive only, and keeps the cleanup logic aligned with the same behavior.

## Reproduction

A simplified example of the previous behavior:

```html
<meta
  http-equiv="Content-Security-Policy"
  content="default-src 'none'; script-src-elem 'self'; script-src 'self'"
/>
```

The previous replacement could produce:

```html
script-src 'unsafe-inline'-elem
```

instead of updating the actual `script-src` directive.

## Changes

- only inject `'unsafe-inline'` into the real `script-src` directive
- avoid matching `script-src-elem` and similar directive names
- keep uninstall / cleanup behavior consistent with the updated injection logic

## Notes

This is a defensive fix for CSP patching correctness. It does not change the extension's intended behavior beyond making the HTML patching logic more precise.

fix: #630