### PR TITLE
fix: apply editor background in floating editor windows (fix #633)

### DIFF
--- a/src/background/PatchGenerator/PatchGenerator.editor.ts
+++ b/src/background/PatchGenerator/PatchGenerator.editor.ts
@@ -52,7 +52,10 @@ export class EditorPatchGenerator extends AbsPatchGenerator<EditorPatchGenerator
                 opacity: 0.8;
             }
 
-            [id='workbench.parts.editor'] .split-view-view {
+            /* 主窗口的 editor part 是 #workbench.parts.editor，
+               而浮动编辑器窗口（auxiliary window）的 editor part 只有 class 没有 id，
+               所以这里用 class 选择器同时覆盖两者 */
+            .monaco-workbench .part.editor .split-view-view {
                 /* 处理一块背景色遮挡 */
                 .editor-container .overflow-guard > .monaco-scrollable-element > .monaco-editor-background {
                     background: none;


### PR DESCRIPTION
Fixes #633.

The editor background never appears in a floating editor window. The CSS reaches that window fine, it cannot match anything there.

VS Code writes the DOM id onto a part only for the main window, in `Workbench.createPart` (`part.id = id`). A floating window builds its editor part in `AuxiliaryEditorPart.create` as `$('.part.editor', { role: 'main' })`, with no id. So `[id='workbench.parts.editor'] .split-view-view …` matches zero nodes in that document and the `::after` overlay never renders. Switching the prefix to `.monaco-workbench .part.editor` matches both windows: the main window's part carries `class="part editor"` alongside its id, and the auxiliary window's container inherits the workbench classes because `BrowserAuxiliaryWindowService.applyHTML` tracks the class attribute from the main container.

Nothing else needed changing. The sidebar, panel, auxiliarybar and fullscreen generators already use class selectors, and auxiliary windows do receive the injected stylesheet. `applyCSS` clones every `<style>` and stylesheet `<link>` out of the main document head, then keeps a `MutationObserver` on it for nodes added later and for text changes to nodes it already cloned, so the `interval` rotation carries across too.

### Verification

I tested this end to end on a clean VS Code 1.136.0 in a fresh Windows Sandbox, driving the real UI over the remote debugging protocol: install the extension from a `.vsix`, run `Background: Install`, move the editor into a new window, then probe that window.

Before the change, the floating window has the extension's stylesheet, with the rule text present verbatim as `[id='workbench.parts.editor'] …`, but `[id='workbench.parts.editor']` matches 0 nodes while `.part.editor` matches 1, and the computed `::after` `background-image` is `none`. After the change the same probe returns `url("vscode-file://vscode-app/…/bg.png")` with `z-index: 99`. The main window behaves the same either way, same computed background before and after.

Same floating window, before and after, with a solid magenta test image configured so I could tell at a glance whether it rendered:

| before | after |
| --- | --- |
| <img width="958" height="768" alt="image" src="https://github.com/user-attachments/assets/76b64ef1-e9ef-4109-81d9-12b62f5040bd" /> | <img width="958" height="768" alt="image" src="https://github.com/user-attachments/assets/1e323512-2799-4a9d-ae32-735338e4e6af" /> |

I only tested 1.136.0 on Windows desktop. The reporter is on 1.132.1; I diffed `auxiliaryEditorPart.ts` and `workbench.ts` at both tags and the relevant code is identical, but I did not run 1.132.1. I also tested a single image with `useFront: true` and nothing else, so `useFront: false`, multiple images, and `interval` rotation inside a floating window are all unexercised.

One pre-existing limitation this does not address: the per-image rules key off `:nth-child(Nn + i)` over `.split-view-view`, and a floating window's group is `:nth-child(1)` in its own document, so with several images configured the floating window always shows the first one instead of following the main window's sequence. I left that out of scope here, though I can take it on separately if you want it.

### Checklist - en

- [x] Read our [Contributing Guide](https://github.com/shalldie/vscode-background/blob/master/docs/contributing.md).
- [x] Associate an issue with the Pull Request.
- [x] Ensure that the code is up-to-date with the `master` branch.
- [x] Include a description of the proposed changes.
